### PR TITLE
refactor: record-auth-api-call/#115

### DIFF
--- a/src/renderer/src/entities/group/api/query/useGroup.query.ts
+++ b/src/renderer/src/entities/group/api/query/useGroup.query.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { groupApi } from "../groupApi";
+import type { GroupCategoryFilter } from "@/entities/group/model/groupCategory";
+
+export const useAllGroupsQuery = (
+  page: number,
+  category: GroupCategoryFilter,
+  pageSize: number = 6
+) => {
+  return useQuery({
+    queryKey: ["groups", page, pageSize, category],
+    queryFn: () => groupApi.getAllGroups(page, pageSize, category),
+  });
+};
+
+export const useMyGroupsQuery = (page: number = 1, pageSize: number = 20) => {
+  return useQuery({
+    queryKey: ["myGroups", page, pageSize],
+    queryFn: () => groupApi.getMyGroups(page, pageSize),
+  });
+};
+
+export const useGroupActivityQuery = (groupId: number | null) => {
+  return useQuery({
+    queryKey: ["groupActivity", groupId],
+    queryFn: () => groupApi.getGroupActivity(groupId ?? 0),
+    enabled: groupId !== null,
+  });
+};
+
+export const useGroupDetailQuery = (groupId: number | null) => {
+  return useQuery({
+    queryKey: ["groupDetail", groupId],
+    queryFn: () => groupApi.getGroupDetail(groupId ?? 0),
+    enabled: groupId !== null,
+    staleTime: 0,
+  });
+};

--- a/src/renderer/src/entities/group/index.ts
+++ b/src/renderer/src/entities/group/index.ts
@@ -1,4 +1,10 @@
 export { groupApi } from "./api/groupApi";
+export {
+  useAllGroupsQuery,
+  useGroupActivityQuery,
+  useGroupDetailQuery,
+  useMyGroupsQuery,
+} from "./api/query/useGroup.query";
 export type {
   Owner,
   Group,

--- a/src/renderer/src/entities/record/api/query/useRecord.query.ts
+++ b/src/renderer/src/entities/record/api/query/useRecord.query.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { recordApi } from "../recordApi";
+
+export const recordQueryKeys = {
+  tasks: ["record", "tasks"] as const,
+  today: ["record", "today"] as const,
+};
+
+export const useRecordTasksQuery = () => {
+  return useQuery({
+    queryKey: recordQueryKeys.tasks,
+    queryFn: () => recordApi.getTasks(),
+  });
+};
+
+export const useRecordTodayQuery = () => {
+  return useQuery({
+    queryKey: recordQueryKeys.today,
+    queryFn: () => recordApi.getToday(),
+  });
+};

--- a/src/renderer/src/entities/record/index.ts
+++ b/src/renderer/src/entities/record/index.ts
@@ -1,4 +1,9 @@
 export { recordApi } from "./api/recordApi";
+export {
+  recordQueryKeys,
+  useRecordTasksQuery,
+  useRecordTodayQuery,
+} from "./api/query/useRecord.query";
 export type {
   Task,
   Session,

--- a/src/renderer/src/features/record/model/useGroupList.ts
+++ b/src/renderer/src/features/record/model/useGroupList.ts
@@ -1,49 +1,24 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
-  GROUP_CATEGORY_FILTERS,
   type Group,
+  GROUP_CATEGORY_FILTERS,
   type GroupCategoryFilter,
-  groupApi,
+  useAllGroupsQuery,
 } from "@/entities/group";
 import type { Pagination } from "@/shared/api/types";
-import axios from "axios";
 
 export const useGroupList = () => {
-  const [groups, setGroups] = useState<Group[]>([]);
-  const [pagination, setPagination] = useState<Pagination | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState<GroupCategoryFilter>("ALL");
 
-  const fetchGroups = async (page: number, category: GroupCategoryFilter) => {
-    try {
-      setIsLoading(true);
-      const result = await groupApi.getAllGroups(page, 6, category);
+  const {
+    data: groupsResponse,
+    isLoading,
+    refetch,
+  } = useAllGroupsQuery(currentPage, selectedCategory);
 
-      if (result.success && result.data) {
-        setGroups(result.data.groups);
-        setPagination(result.data.pagination);
-      } else {
-        console.error("그룹 목록 조회 실패:", result.message);
-      }
-    } catch (error: unknown) {
-      console.error("그룹 목록 조회 실패:", error);
-
-      if (axios.isAxiosError(error)) {
-        const errorMessage =
-          error.response?.data?.error?.message ||
-          error.response?.data?.message ||
-          "그룹 목록 조회 중 오류가 발생했습니다.";
-        console.error(errorMessage);
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchGroups(currentPage, selectedCategory);
-  }, [currentPage, selectedCategory]);
+  const groups: Group[] = groupsResponse?.data?.groups ?? [];
+  const pagination: Pagination | null = groupsResponse?.data?.pagination ?? null;
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -63,6 +38,8 @@ export const useGroupList = () => {
     categoryOptions: GROUP_CATEGORY_FILTERS,
     handlePageChange,
     handleCategoryChange,
-    refetch: () => fetchGroups(currentPage, selectedCategory),
+    refetch: () => {
+      void refetch();
+    },
   };
 };

--- a/src/renderer/src/features/record/model/useGroupMembersActivity.ts
+++ b/src/renderer/src/features/record/model/useGroupMembersActivity.ts
@@ -1,28 +1,25 @@
-import { useState, useCallback } from "react";
-import { groupApi, type GroupMember } from "@/entities/group";
+import { useCallback, useMemo, useState } from "react";
+import { type GroupMember, useGroupActivityQuery } from "@/entities/group";
 
-export const useGroupMembersActivity = () => {
-  const [groupMembers, setGroupMembers] = useState<GroupMember[]>([]);
+export const useGroupMembersActivity = (groupId: number | null) => {
+  const { data: activityResponse, dataUpdatedAt } = useGroupActivityQuery(groupId);
+  const [now, setNow] = useState(() => Date.now());
+  const elapsedSeconds =
+    dataUpdatedAt > 0 ? Math.max(0, Math.floor((now - dataUpdatedAt) / 1000)) : 0;
 
-  const fetchGroupMembers = useCallback(async (groupId: number) => {
-    const response = await groupApi.getGroupActivity(groupId);
-
-    if (response.data) {
-      setGroupMembers(response.data.members);
-    }
-  }, []);
+  const groupMembers = useMemo(() => {
+    const members: GroupMember[] = activityResponse?.data?.members ?? [];
+    return members.map(member =>
+      member.isStudying ? { ...member, studyTime: member.studyTime + elapsedSeconds } : member
+    );
+  }, [activityResponse, elapsedSeconds]);
 
   // 조회한 그룹 멤버 중 공부 중인 멤버의 공부 시간을 1초 늘리는 Callback 함수
   const incrementStudyingMembers = useCallback(() => {
-    setGroupMembers(prev =>
-      prev.map(member =>
-        member.isStudying ? { ...member, studyTime: member.studyTime + 1 } : member
-      )
-    );
+    setNow(Date.now());
   }, []);
 
   return {
-    fetchGroupMembers,
     groupMembers,
     incrementStudyingMembers,
   };


### PR DESCRIPTION
## 변경사항

- record/group 영역의 GET 조회를 `useEffect + 직접 API 호출`에서 `useQuery` 로 통일
- `useRecord.query.ts`, `useGroup.query.ts` 조회 훅 정리
- `recordStore`의 `fetchTasks` 제거

## 관련 이슈

Closes #115

## 스크린샷/동영상

## 추가 컨텍스트
- record/group은 추후 socket 전환 예정이라서 컨벤션 정리(useQuery 통일) 범위 안에서만 수정하였습니다.
- auth 도메인은 수정할 부분이 없습니다.