### PR TITLE
refactor: create-common-confirm-dialog/#161

### DIFF
--- a/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.style.ts
+++ b/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.style.ts
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+import { font } from "@/shared/config/font";
+import { palette } from "@/shared/config/theme";
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0 0 0;
+  height: 100%;
+`;
+
+export const MessageBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+export const Description = styled.p`
+  ${font.body.medium};
+  color: ${({ theme }) => theme.label.normal};
+`;
+
+export const ConfirmMessage = styled.p`
+  ${font.body.medium};
+  color: ${palette.red[60]};
+`;
+
+export const ActionBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+`;

--- a/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.tsx
+++ b/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.tsx
@@ -1,0 +1,46 @@
+import { Modal } from "@/shared/ui/modal/Modal";
+import { Button } from "@/shared/ui/button";
+import * as S from "./ConfirmDialog.style";
+
+export interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmMessage?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isConfirming?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export const ConfirmDialog = ({
+  isOpen,
+  title,
+  description,
+  confirmMessage,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  isConfirming = false,
+  onClose,
+  onConfirm,
+}: ConfirmDialogProps) => {
+  return (
+    <Modal width={23} height={13} isOpen={isOpen} onClose={onClose} modalTitle={title} gap={3}>
+      <S.Content>
+        <S.MessageBox>
+          <S.Description>{description}</S.Description>
+          {confirmMessage && <S.ConfirmMessage>{confirmMessage}</S.ConfirmMessage>}
+        </S.MessageBox>
+        <S.ActionBox>
+          <Button variant="secondary" size="lg" onClick={onClose} disabled={isConfirming}>
+            {cancelLabel}
+          </Button>
+          <Button variant="primary" size="lg" onClick={onConfirm} disabled={isConfirming}>
+            {isConfirming ? `${confirmLabel} 중...` : confirmLabel}
+          </Button>
+        </S.ActionBox>
+      </S.Content>
+    </Modal>
+  );
+};

--- a/src/renderer/src/shared/ui/confirm-dialog/index.ts
+++ b/src/renderer/src/shared/ui/confirm-dialog/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmDialog } from "./ConfirmDialog";
+export type { ConfirmDialogProps } from "./ConfirmDialog";

--- a/src/renderer/src/shared/ui/index.ts
+++ b/src/renderer/src/shared/ui/index.ts
@@ -1,2 +1,4 @@
 export { Button } from "./button";
 export type { ButtonProps, ButtonSize, ButtonVariant } from "./button";
+export { ConfirmDialog } from "./confirm-dialog";
+export type { ConfirmDialogProps } from "./confirm-dialog";


### PR DESCRIPTION
## 변경사항

- `shared/ui/confirm-dialog` 공통 컴포넌트를 추가했습니다.
- ConfirmDialog 내부 액션 버튼은 `shared/ui/button`을 사용하도록 통일했습니다.

## 관련 이슈

Closes #161

## 사용 예시

```tsx
import { ConfirmDialog } from "@/shared/ui";

<ConfirmDialog
  isOpen={isDeleteOpen}
  title="과목 삭제"
  description="정말 해당 과목을 삭제하시겠습니까?"
  confirmMessage="삭제 시 해당 과목의 데이터가 모두 삭제됩니다"
  confirmLabel="삭제"
  cancelLabel="취소"
  onClose={handleCloseDelete}
  onConfirm={handleConfirmDelete}
/>
