### PR TITLE
hotfix: 내 기록 비교 UI 및 이전데이터와 비교 로직

### DIFF
--- a/src/renderer/src/features/competition/model/useMyCompetition.ts
+++ b/src/renderer/src/features/competition/model/useMyCompetition.ts
@@ -23,14 +23,15 @@ const growthRateDropDownValue: { key: GrowthRateStandard; label: string }[] = [
 
 export const useMyCompetition = () => {
   const [competitionDropdown, setCompetitionDropdown] = useState<CompareStandard>("TODAY");
+
   const [growthRateDropdown, setGrowthRateDropdown] = useState<GrowthRateStandard>("DAY");
 
+  const { data: todayResponse } = useMyCompareQuery("TODAY");
   const { data: compareResponse, isLoading: isCompareLoading } =
     useMyCompareQuery(competitionDropdown);
 
   const { data: growthRateResponse } = useMyGrowthRateQuery(growthRateDropdown);
 
-  // 첫번쨰 소수점까지 정리식
   const oneDecimal = (value?: number | null) => (value == null ? 0 : Math.trunc(value * 10) / 10);
 
   const dataPoints = growthRateResponse?.data?.dataPoint ?? [];
@@ -38,7 +39,8 @@ export const useMyCompetition = () => {
   return {
     dataPoints,
     isCompareLoading,
-    myCompareData: compareResponse?.data,
+    todayData: todayResponse?.data,
+    compareData: compareResponse?.data,
     competitionDropdown,
     setCompetitionDropdown,
     growthRateDropdown,

--- a/src/renderer/src/features/competition/ui/my-competition/WithMyCompetition.tsx
+++ b/src/renderer/src/features/competition/ui/my-competition/WithMyCompetition.tsx
@@ -9,7 +9,8 @@ import { Select } from "@/shared/ui/select";
 export const WithMyCompetition = () => {
   const {
     dataPoints,
-    myCompareData,
+    todayData,
+    compareData,
     competitionDropdown,
     setCompetitionDropdown,
     growthRateDropdown,
@@ -60,64 +61,7 @@ export const WithMyCompetition = () => {
         <S.CompareContainer>
           <S.CompareBox>
             <S.TextBox>
-              <S.CompareBoxTitle>비교1</S.CompareBoxTitle>
-              <S.DateText>오늘</S.DateText>
-            </S.TextBox>
-
-            <S.GridContainer>
-              <S.GridBox>
-                <S.DataBoxing>
-                  <S.ImpressiveBox>
-                    <S.EXPIcon />
-                    <S.ExplainText>총 획득 EXP</S.ExplainText>
-                  </S.ImpressiveBox>
-                  <S.DataText>{oneDecimal(myCompareData?.earnedExp)} EXP</S.DataText>
-                </S.DataBoxing>
-              </S.GridBox>
-
-              <S.GridBox>
-                <S.DataBoxing>
-                  <S.ImpressiveBox>
-                    <S.RecordIcon />
-                    <S.ExplainText>학습시간</S.ExplainText>
-                  </S.ImpressiveBox>
-                  <S.DataText>{oneDecimal(myCompareData?.studyTime)} 시간</S.DataText>
-                </S.DataBoxing>
-              </S.GridBox>
-
-              <S.GridBox>
-                <S.DataBoxing>
-                  <S.ImpressiveBox>
-                    <S.SolvedAcIcon />
-                    <S.ExplainText>
-                      solved.ac
-                      <br />
-                      문제 해결 수
-                    </S.ExplainText>
-                  </S.ImpressiveBox>
-                  <S.DataText>0 문제</S.DataText>
-                </S.DataBoxing>
-              </S.GridBox>
-
-              <S.GridBox>
-                <S.DataBoxing>
-                  <S.ImpressiveBox>
-                    <S.GithubIcon />
-                    <S.ExplainText>
-                      Github
-                      <br />
-                      기여수
-                    </S.ExplainText>
-                  </S.ImpressiveBox>
-                  <S.DataText>{oneDecimal(myCompareData?.gitHubAttribution)}</S.DataText>
-                </S.DataBoxing>
-              </S.GridBox>
-            </S.GridContainer>
-          </S.CompareBox>
-
-          <S.CompareBox>
-            <S.TextBox>
-              <S.CompareBoxTitle>비교2</S.CompareBoxTitle>
+              <S.CompareBoxTitle>이전의 활동량</S.CompareBoxTitle>
               <Select<CompareStandard>
                 value={competitionDropdown}
                 options={competitionDropDownValue}
@@ -132,13 +76,7 @@ export const WithMyCompetition = () => {
                     <S.EXPIcon />
                     <S.ExplainText>총 획득 EXP</S.ExplainText>
                   </S.ImpressiveBox>
-                  <S.GrowthRateBox>
-                    <S.DataText>{oneDecimal(myCompareData?.earnedExp)} EXP</S.DataText>
-                    <GrowthRate
-                      yesterday={oneDecimal(myCompareData?.earnedExp)}
-                      today={oneDecimal(myCompareData?.earnedExp)}
-                    />
-                  </S.GrowthRateBox>
+                  <S.DataText>{oneDecimal(compareData?.earnedExp)} EXP</S.DataText>
                 </S.DataBoxing>
               </S.GridBox>
 
@@ -148,27 +86,7 @@ export const WithMyCompetition = () => {
                     <S.RecordIcon />
                     <S.ExplainText>학습시간</S.ExplainText>
                   </S.ImpressiveBox>
-                  <S.GrowthRateBox>
-                    <S.DataText>{oneDecimal(myCompareData?.studyTime)} 시간</S.DataText>
-                    <GrowthRate
-                      yesterday={oneDecimal(myCompareData?.studyTime)}
-                      today={oneDecimal(myCompareData?.studyTime)}
-                    />
-                  </S.GrowthRateBox>
-                </S.DataBoxing>
-              </S.GridBox>
-
-              <S.GridBox>
-                <S.DataBoxing>
-                  <S.ImpressiveBox>
-                    <S.SolvedAcIcon />
-                    <S.ExplainText>
-                      solved.ac
-                      <br />
-                      문제 해결 수
-                    </S.ExplainText>
-                  </S.ImpressiveBox>
-                  <S.DataText>0 문제</S.DataText>
+                  <S.DataText>{oneDecimal(compareData?.studyTime)} 시간</S.DataText>
                 </S.DataBoxing>
               </S.GridBox>
 
@@ -183,10 +101,67 @@ export const WithMyCompetition = () => {
                     </S.ExplainText>
                   </S.ImpressiveBox>
                   <S.GrowthRateBox>
-                    <S.DataText>{oneDecimal(myCompareData?.gitHubAttribution)}</S.DataText>
+                    <S.DataText>{oneDecimal(compareData?.gitHubAttribution)}개</S.DataText>
+                  </S.GrowthRateBox>
+                </S.DataBoxing>
+              </S.GridBox>
+            </S.GridContainer>
+          </S.CompareBox>
+
+          <S.CompareBox>
+            <S.TextBox>
+              <S.CompareBoxTitle>오늘의 활동량</S.CompareBoxTitle>
+              <S.DateText>오늘</S.DateText>
+            </S.TextBox>
+
+            <S.GridContainer>
+              <S.GridBox>
+                <S.DataBoxing>
+                  <S.ImpressiveBox>
+                    <S.EXPIcon />
+                    <S.ExplainText>총 획득 EXP</S.ExplainText>
+                  </S.ImpressiveBox>
+                  <S.GrowthRateBox>
+                    <S.DataText>{oneDecimal(todayData?.earnedExp)} EXP</S.DataText>
                     <GrowthRate
-                      yesterday={oneDecimal(myCompareData?.gitHubAttribution)}
-                      today={oneDecimal(myCompareData?.gitHubAttribution)}
+                      yesterday={oneDecimal(compareData?.earnedExp)}
+                      today={oneDecimal(todayData?.earnedExp)}
+                    />
+                  </S.GrowthRateBox>
+                </S.DataBoxing>
+              </S.GridBox>
+
+              <S.GridBox>
+                <S.DataBoxing>
+                  <S.ImpressiveBox>
+                    <S.RecordIcon />
+                    <S.ExplainText>학습시간</S.ExplainText>
+                  </S.ImpressiveBox>
+                  <S.GrowthRateBox>
+                    <S.DataText>{oneDecimal(todayData?.studyTime)} 시간</S.DataText>
+                    <GrowthRate
+                      yesterday={oneDecimal(compareData?.studyTime)}
+                      today={oneDecimal(todayData?.studyTime)}
+                    />
+                  </S.GrowthRateBox>
+                </S.DataBoxing>
+              </S.GridBox>
+
+              <S.GridBox>
+                <S.DataBoxing>
+                  <S.ImpressiveBox>
+                    <S.GithubIcon />
+                    <S.ExplainText>
+                      Github
+                      <br />
+                      기여수
+                    </S.ExplainText>
+                  </S.ImpressiveBox>
+                  <S.GrowthRateBox>
+                    <S.DataText>{oneDecimal(todayData?.gitHubAttribution)}개</S.DataText>
+                    <GrowthRate
+                      yesterday={oneDecimal(compareData?.gitHubAttribution)}
+                      today={oneDecimal(todayData?.gitHubAttribution)}
                     />
                   </S.GrowthRateBox>
                 </S.DataBoxing>


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- 내 기록 비교 UI
- 이전데이터를 GrowthRate에 삽입하여 오늘과 비교하는 로직으로 변환

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #

## 스크린샷/동영상

<!-- UI 변경이 있는 경우에만 추가해주세요 -->

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
