### PR TITLE
fix: 총 학습 시간 데이터가 초단위 숫자로만 보이는 버그

### DIFF
--- a/src/renderer/src/features/competition/model/useBattle.ts
+++ b/src/renderer/src/features/competition/model/useBattle.ts
@@ -87,7 +87,7 @@ export const useBattle = () => {
 
   const detailTextTranslate = (category: AnalyzeCategory) => {
     if (category === "GITHUB") return "Contributes";
-    if (category === "ACTIVE_TIME") return "Time";
+    if (category === "ACTIVE_TIME") return;
     return "EXP";
   };
 

--- a/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
+++ b/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
@@ -2,6 +2,7 @@ import * as S from "./Battle.style";
 import { Dialog } from "@/shared/ui";
 import { AnalyzeCategory, MATCHVALUE } from "@/entities/competition";
 import { useBattle } from "@/features/competition/model/useBattle";
+import { formatTime } from "@/shared/lib";
 
 export const Battle = () => {
   const battle = useBattle();
@@ -135,7 +136,9 @@ export const Battle = () => {
                             <S.AnalyzeBar $width={battle.rivalAnalyzeRate ?? 0} $isRival>
                               <S.AnalyzeLabel>
                                 <div>
-                                  {Math.round(battle.rivalAnalyzePoint ?? 0)}{" "}
+                                  {battle.category === "ACTIVE_TIME"
+                                    ? formatTime(Math.round(battle.rivalAnalyzePoint) ?? 0)
+                                    : Math.round(battle.rivalAnalyzePoint ?? 0)}{" "}
                                   {battle.detailTextTranslate(battle.category)}
                                 </div>
                                 {battle.isRivalHigher && (battle.diff ?? 0) > 0 && (
@@ -147,7 +150,9 @@ export const Battle = () => {
                             <S.AnalyzeBar $width={battle.myAnalyzeRate ?? 0} $isRival={false}>
                               <S.AnalyzeLabel>
                                 <div>
-                                  {Math.round(battle.myAnalyzePoint ?? 0)}{" "}
+                                  {battle.category === "ACTIVE_TIME"
+                                    ? formatTime(Math.round(battle.myAnalyzePoint) ?? 0)
+                                    : Math.round(battle.myAnalyzePoint ?? 0)}{" "}
                                   {battle.detailTextTranslate(battle.category)}
                                 </div>
                                 {!battle.isRivalHigher && (battle.diff ?? 0) > 0 && (


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- 배틀: 나와 라이벌의 총 학습 시간이 초단위로만 보이는 로직을 수정

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
