### PR TITLE
refactor: switch-app-monitoring-to-lsappinfo/#284

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clash-client",
   "productName": "Process Clash",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "학습 기록을 통한 경쟁 애플리케이션, Clash",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
## 변경사항

- 앱 모니터링 구현을 `osascript/System Events` 기반에서 `lsappinfo` 기반으로 전환했습니다.

## 관련 이슈

Closes #284

## 스크린샷/동영상

- UI 변경 없음

## 추가 컨텍스트

- macOS 권한 상태에 따라 모니터링 동작이 불안정한 문제를 해결하기 위해 권한 의존성을 제거했습니다.