### PR TITLE
fix: logout-session-restored-after-restart/#293

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell } from "electron";
+import { ipcMain, session, shell } from "electron";
 import type { AppMonitor } from "../services";
 
 // AppMonitor 및 외부 URL 열기 관련 IPC를 등록합니다.
@@ -23,5 +23,10 @@ export const registerIpcHandlers = (getAppMonitor: () => AppMonitor | null) => {
   });
   ipcMain.handle("open-external-url", async (_, url: string) => {
     await shell.openExternal(url);
+  });
+
+  // 인증 세션(쿠키) 정리
+  ipcMain.handle("auth:clear-session", async () => {
+    await session.defaultSession.clearStorageData({ storages: ["cookies"] });
   });
 };

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -26,6 +26,7 @@ interface AppMonitorAPI {
   getSessions: () => Promise<MonitoringSession[]>;
   getFrontmostMonitoredApp: () => Promise<string | null>;
   openExternalUrl: (url: string) => Promise<void>;
+  clearAuthSession: () => Promise<void>;
   onDeepLinkAuth: (callback: (payload: DeepLinkAuthPayload) => void) => () => void;
   onAppChanged: (callback: (app: ActiveApp | null) => void) => () => void;
   onSessionUpdated: (callback: (session: MonitoringSession) => void) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,7 @@ const api = {
   getFrontmostMonitoredApp: () => ipcRenderer.invoke("app-monitor:get-frontmost-monitored-app"),
 
   openExternalUrl: (url: string) => ipcRenderer.invoke("open-external-url", url),
+  clearAuthSession: () => ipcRenderer.invoke("auth:clear-session"),
 
   onAppChanged: callback => {
     const subscription = (_, app) => callback(app);

--- a/src/renderer/src/features/auth/sign-out/model/useSignOut.ts
+++ b/src/renderer/src/features/auth/sign-out/model/useSignOut.ts
@@ -17,16 +17,24 @@ export const useSignOut = () => {
 
       // 서버에 로그아웃 요청
       await authApi.signOut();
+    } catch (error: unknown) {
+      console.error("로그아웃 실패:", error);
+      setError(getErrorMessage(error, "로그아웃에 실패했습니다."));
+    } finally {
+      // 재실행 시 세션 복원을 막기 위해 Electron 쿠키를 강제로 비움
+      if (typeof window !== "undefined" && window.api?.clearAuthSession) {
+        try {
+          await window.api.clearAuthSession();
+        } catch (error) {
+          console.error("세션 쿠키 정리에 실패했습니다:", error);
+        }
+      }
 
       // 모든 캐시 제거
       queryClient.clear();
 
       // 로그인 페이지로 이동
       navigate("/sign-in", { replace: true });
-    } catch (error: unknown) {
-      console.error("로그아웃 실패:", error);
-      setError(getErrorMessage(error, "로그아웃에 실패했습니다."));
-    } finally {
       setIsLoading(false);
     }
   };


### PR DESCRIPTION
## 변경사항
- 로그아웃 시 Electron 세션 쿠키를 강제로 삭제하도록 처리했습니다.
- auth:clear-session IPC를 추가하고, 로그아웃 호출을 보낼 때 로그아웃 후 clear-session IPC를 호출하도록 변경했습니다.
- 로그아웃 실패 여부와 관계없이 로컬 캐시 정리 후 로그인 화면으로 이동하도록 정리했습니다.

## 관련 이슈
Closes #293

## 스크린샷/동영상
- 없음 (UI 변경 없음)

## 추가 컨텍스트