### PR TITLE
refactor: battle detail text/#289

### DIFF
--- a/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.style.ts
+++ b/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.style.ts
@@ -341,7 +341,8 @@ export const AnalyzeContent = styled.div<{ $width?: string }>`
 `;
 
 export const AnalyzeName = styled.p`
-  ${font.caption.bold}
+  width: 100%;
+  ${font.body.bold}
   color: ${({ theme }) => theme.label.normal};
 `;
 

--- a/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
+++ b/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
@@ -125,7 +125,7 @@ export const Battle = () => {
 
                       <S.AnalyzeBox>
                         <S.AnalyzeRow>
-                          <S.AnalyzeContent>
+                          <S.AnalyzeContent $width="4rem">
                             <S.AnalyzeName>{battle.battleDetailData?.enemy.name}</S.AnalyzeName>
                             <S.AnalyzeName>나</S.AnalyzeName>
                           </S.AnalyzeContent>


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- 배틀 세부 분석 페이지, 전체적인 텍스트 크기 증가

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #289 

## 스크린샷/동영상
<img width="495" height="394" alt="스크린샷 2026-02-26 15 55 54" src="https://github.com/user-attachments/assets/65e1e0ff-5a2a-48f4-a4db-17bb03a509c3" />

<!-- UI 변경이 있는 경우에만 추가해주세요 -->

## 추가 컨텍스트
현재 텍스트 크기 증가로 인해 살짝 레이아웃이 이상한 느낌이 드네요.
다음 이슈 작업에서 padding을 늘리겠습니다.
<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
