### PR TITLE
fix: subject-delete-session-continue/#314

### DIFF
--- a/src/renderer/src/features/record/model/useTaskList.ts
+++ b/src/renderer/src/features/record/model/useTaskList.ts
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useRecordStore } from "./recordStore";
 import { recordApi, recordQueryKeys, useRecordTodayQuery } from "@/entities/record";
+import type { TaskRecordSession } from "@/entities/record";
 import { getErrorMessage, queryClient } from "@/shared/lib";
 
 type EditMode = "none" | "add" | "edit";
@@ -25,6 +26,19 @@ export const useTaskList = () => {
     todayResponse.data?.sessions.some(
       session => session.endedAt === null && session.recordType === "ACTIVITY"
     )
+  );
+  const activeTaskSessionId =
+    todayResponse?.success && todayResponse.data
+      ? ((
+          todayResponse.data.sessions.find(
+            (session): session is TaskRecordSession =>
+              session.endedAt === null && session.recordType === "TASK"
+          ) ?? null
+        )?.task.id ?? null)
+      : null;
+  const isDeletingActiveTask = Boolean(
+    deleteTargetId !== null &&
+    (activeTaskId === deleteTargetId || activeTaskSessionId === deleteTargetId)
   );
 
   const handlePlayPauseClick = async (taskId: number) => {
@@ -149,6 +163,7 @@ export const useTaskList = () => {
     taskName,
     openMenuTaskId,
     deleteTargetId,
+    isDeletingActiveTask,
     activitySwitchTargetTaskId,
     isSwitchingFromActivity,
     menuRef,

--- a/src/renderer/src/features/record/ui/task/Task.tsx
+++ b/src/renderer/src/features/record/ui/task/Task.tsx
@@ -11,6 +11,7 @@ export const Task = () => {
     taskName,
     openMenuTaskId,
     deleteTargetId,
+    isDeletingActiveTask,
     activitySwitchTargetTaskId,
     isSwitchingFromActivity,
     menuRef,
@@ -118,10 +119,20 @@ export const Task = () => {
       </S.TaskContainer>
       <ConfirmDialog
         isOpen={deleteTargetId !== null}
-        title="과목 삭제"
-        description="정말 해당 과목을 삭제하시겠습니까?"
+        title={isDeletingActiveTask ? "진행 중 과목 삭제" : "과목 삭제"}
+        description={
+          isDeletingActiveTask ? (
+            <>
+              현재 진행 중인 세션이 있습니다.
+              <br />
+              과목을 삭제하면 세션이 종료됩니다.
+            </>
+          ) : (
+            "정말 해당 과목을 삭제하시겠습니까?"
+          )
+        }
         confirmMessage="삭제 시 해당 과목의 데이터가 모두 삭제됩니다"
-        confirmLabel="삭제"
+        confirmLabel={isDeletingActiveTask ? "종료 후 삭제" : "삭제"}
         confirmVariant="danger"
         onClose={handleCancelDelete}
         onConfirm={handleConfirmDelete}

--- a/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.tsx
+++ b/src/renderer/src/shared/ui/confirm-dialog/ConfirmDialog.tsx
@@ -1,12 +1,13 @@
 import { Dialog } from "@/shared/ui";
 import type { ButtonVariant } from "@/shared/ui/button";
 import { ModalActions } from "@/shared/ui/dialog-actions";
+import type { ReactNode } from "react";
 import * as S from "./ConfirmDialog.style";
 
 export interface ConfirmDialogProps {
   isOpen: boolean;
   title: string;
-  description: string;
+  description: ReactNode;
   confirmMessage?: string;
   confirmLabel?: string;
   cancelLabel?: string;
@@ -43,7 +44,7 @@ export const ConfirmDialog = ({
           confirmLabel={isConfirming ? `${confirmLabel} 중...` : confirmLabel}
           confirmDisabled={isConfirming}
           confirmVariant={confirmVariant}
-          size="md"
+          size="sm"
         />
       </S.Content>
     </Dialog>

--- a/src/renderer/src/shared/ui/dialog-actions/ModalActions.tsx
+++ b/src/renderer/src/shared/ui/dialog-actions/ModalActions.tsx
@@ -23,7 +23,7 @@ export const ModalActions = ({
   confirmDisabled = false,
   confirmType = "button",
   confirmVariant = "primary",
-  size = "md",
+  size = "sm",
 }: ModalActionsProps) => {
   return (
     <S.ActionRow>


### PR DESCRIPTION
## 변경사항

- 과목 삭제 Confirm Dialog를 진행 중 과목 여부에 따라 분기하도록 수정했습니다.
- ConfirmDialog 컴포넌트의 description 타입을 string에서 ReactNode로 변경해 <br  줄바꿈이 작동하도록 수정했습니다.

## 관련 이슈

Closes #314

## 스크린샷/동영상

## 추가 컨텍스트