### PR TITLE
fix: battle-percent-text-zindex/#356

### DIFF
--- a/apps/mac/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.style.ts
+++ b/apps/mac/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.style.ts
@@ -257,7 +257,6 @@ export const PercentText = styled.p<{ $isRival: boolean }>`
   ${palette.neutral[99]}
   position: absolute;
   opacity: 0.6;
-  z-index: 1000;
   padding-left: ${({ $isRival }) => ($isRival ? "0.5rem" : "0")};
   padding-right: ${({ $isRival }) => ($isRival ? "0" : "0.5rem")};
 `;


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- z-index: 1000으로 인한 텍스트 플로팅이 존재했습니다. 그냥 삭제하니 픽스 되었습니다. ㅎ

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #356 

## 스크린샷/동영상
<img width="556" height="193" alt="스크린샷 2026-03-05 21 19 38" src="https://github.com/user-attachments/assets/10f6db41-9a79-4ac3-9260-f77590e35798" />

<!-- UI 변경이 있는 경우에만 추가해주세요 -->

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
