### PR TITLE
fix: save-cookie/#390

### DIFF
--- a/apps/mac/src/main/lifecycle/index.ts
+++ b/apps/mac/src/main/lifecycle/index.ts
@@ -134,6 +134,7 @@ export const registerQuitHandlers = ({ getAppMonitor }: RegisterQuitHandlersPara
       try {
         await Promise.race([stopRecordSessionOnShutdown(), wait(SHUTDOWN_CLEANUP_TIMEOUT_MS)]);
       } finally {
+        await session.defaultSession.cookies.flushStore();
         app.exit(0);
       }
     })();


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- 종료 시 쿠키 강제 저장

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #390 

## 스크린샷/동영상

<!-- UI 변경이 있는 경우에만 추가해주세요 -->

## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
1. 사용 중 API 요청 발생 → 서버 응답의 Set-Cookie로 쿠키 갱신 (remember-me 포함)                                                                                                   
                                                                                                                                                                                     
2. 이 갱신이 Chromium의 30초 flush 타이머를 리셋                                                                                                                                   
                                                                                                                                                                                     
3. app.exit(0) → 타이머 만료 전에 종료 → 메모리의 쿠키 상태가 디스크에 안 쓰임                                                                                                     
                                                                                                                                                                                     
4. 다음 실행 시 디스크에서 읽으면 이전 상태 (혹은 없음)