### PR TITLE
hotfix: roeadmap-ux

### DIFF
--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.style.ts
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.style.ts
@@ -108,30 +108,34 @@ export const OverviewBody = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 0.875rem;
+  gap: 1.35rem;
   min-height: 0;
 `;
 
 export const SectionCard = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 0.875rem;
-  padding: 1rem 1rem;
-  border-radius: 0.85rem;
-  background-color: ${neutralSurface};
-  border: 1px solid ${subtleBorder};
-  box-shadow: none;
+  gap: 0.9rem;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+
+  & + & {
+    padding-top: 1.3rem;
+    border-top: 1px solid ${subtleBorder};
+  }
 `;
 
 export const SectionTitle = styled.h3`
   ${font.body.medium}
   color: ${({ theme }) => theme.label.strong};
+  letter-spacing: -0.01em;
 `;
 
 export const ProgressSummary = styled.div`
   display: flex;
   align-items: baseline;
-  gap: 0.35rem;
+  gap: 0.45rem;
 `;
 
 export const ProgressCurrent = styled.span`
@@ -150,7 +154,7 @@ export const ProgressTrack = styled.div`
   height: 0.5rem;
   border-radius: 999px;
   overflow: hidden;
-  background-color: rgba(255, 255, 255, 0.14);
+  background-color: rgba(255, 255, 255, 0.1);
 `;
 
 export const ProgressFill = styled.div<{ $value: number }>`
@@ -165,6 +169,7 @@ export const MetaRow = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 0.75rem;
+  padding-top: 0.15rem;
 `;
 
 export const MetaItem = styled.div`
@@ -189,6 +194,7 @@ export const DescriptionText = styled.p`
   line-height: 1.65;
   white-space: pre-wrap;
   word-break: keep-all;
+  max-width: 34rem;
 `;
 
 export const InlineMessage = styled.p<{ $tone?: "error" | "neutral" }>`
@@ -220,6 +226,8 @@ export const FooterActions = styled.div`
   flex-direction: column;
   gap: 0.75rem;
   margin-top: auto;
+  padding-top: 1.5rem;
+  border-top: 1px solid ${subtleBorder};
 `;
 
 export const PrimaryActionButton = styled(Button)`
@@ -247,6 +255,7 @@ export const QuizBody = styled.div`
   flex-direction: column;
   gap: 0.875rem;
   min-height: 0;
+  overflow: hidden;
 `;
 
 export const BackButton = styled.button`
@@ -295,12 +304,42 @@ export const QuizCard = styled.section`
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  margin-top: 1.1rem;
   padding: 0;
   border-radius: 0;
   background-color: transparent;
   border: none;
   align-items: center;
+`;
+
+export const QuizViewport = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0 1.25rem;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.line.normal};
+    border-radius: 999px;
+  }
+`;
+
+export const QuizContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  margin-block: auto;
 `;
 
 export const QuestionText = styled.p`
@@ -320,16 +359,14 @@ export const OptionList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
-  margin-top: 0.75rem;
+  width: 100%;
   align-items: center;
 `;
 
 export const ResultCard = styled(QuizCard)`
-  flex: 1;
   width: 100%;
   gap: 1.35rem;
-  margin-top: 1.25rem;
-  min-height: 0;
+  margin-block: auto;
 `;
 
 export const ResultHeader = styled.div`
@@ -380,10 +417,10 @@ export const ResultFooterActions = styled.div`
   display: flex;
   justify-content: center;
   width: 100%;
-  margin-top: auto;
+  padding-top: 1rem;
 
   & > * {
-    width: min(100%, 24rem);
+    width: 100%;
     flex: none;
   }
 `;

--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
@@ -68,15 +68,17 @@ const QuizPanelContent = ({
           <S.BackArrow>‹</S.BackArrow>
           챕터 정보
         </S.BackButton>
-        <S.ResultCard>
-          <S.ResultHeader>
-            <S.IncorrectIcon />
-            <S.ResultTextGroup>
-              <S.ResultTitle>문제 정보를 불러오지 못했습니다.</S.ResultTitle>
-              <S.ResultCaption>잠시 후 다시 시도해주세요.</S.ResultCaption>
-            </S.ResultTextGroup>
-          </S.ResultHeader>
-        </S.ResultCard>
+        <S.QuizViewport>
+          <S.ResultCard>
+            <S.ResultHeader>
+              <S.IncorrectIcon />
+              <S.ResultTextGroup>
+                <S.ResultTitle>문제 정보를 불러오지 못했습니다.</S.ResultTitle>
+                <S.ResultCaption>잠시 후 다시 시도해주세요.</S.ResultCaption>
+              </S.ResultTextGroup>
+            </S.ResultHeader>
+          </S.ResultCard>
+        </S.QuizViewport>
       </S.QuizBody>
     );
   }
@@ -98,27 +100,29 @@ const QuizPanelContent = ({
           챕터 정보
         </S.BackButton>
 
-        <S.ResultCard>
-          <S.ResultHeader>
-            {state.lastResult ? <S.CorrectIcon /> : <S.IncorrectIcon />}
-            <S.ResultTextGroup>
-              <S.ResultTitle>{state.lastResult ? "정답입니다." : "오답입니다."}</S.ResultTitle>
-              <S.ResultCaption>해설을 확인하고 다음 문제로 넘어가세요.</S.ResultCaption>
-            </S.ResultTextGroup>
-          </S.ResultHeader>
+        <S.QuizViewport>
+          <S.ResultCard>
+            <S.ResultHeader>
+              {state.lastResult ? <S.CorrectIcon /> : <S.IncorrectIcon />}
+              <S.ResultTextGroup>
+                <S.ResultTitle>{state.lastResult ? "정답입니다." : "오답입니다."}</S.ResultTitle>
+                <S.ResultCaption>해설을 확인하고 다음 문제로 넘어가세요.</S.ResultCaption>
+              </S.ResultTextGroup>
+            </S.ResultHeader>
 
-          <S.ExplanationBox>
-            <S.ExplanationText>
-              {state.explanation || "해설이 제공되지 않았습니다."}
-            </S.ExplanationText>
-          </S.ExplanationBox>
+            <S.ExplanationBox>
+              <S.ExplanationText>
+                {state.explanation || "해설이 제공되지 않았습니다."}
+              </S.ExplanationText>
+            </S.ExplanationBox>
+          </S.ResultCard>
+        </S.QuizViewport>
 
-          <S.ResultFooterActions>
-            <S.PrimaryActionButton variant="primary" size="lg" fullWidth onClick={handleNextOrClose}>
-              {state.currentIndex === questions.length - 1 ? "결과 보기" : "다음 문제로"}
-            </S.PrimaryActionButton>
-          </S.ResultFooterActions>
-        </S.ResultCard>
+        <S.ResultFooterActions>
+          <S.PrimaryActionButton variant="primary" size="lg" fullWidth onClick={handleNextOrClose}>
+            {state.currentIndex === questions.length - 1 ? "결과 보기" : "다음 문제로"}
+          </S.PrimaryActionButton>
+        </S.ResultFooterActions>
       </S.QuizBody>
     );
   }
@@ -195,21 +199,25 @@ const QuizPanelContent = ({
         챕터 정보
       </S.BackButton>
 
-      <S.QuizCard>
-        <S.QuestionText><span>Q.</span> {currentQuestion.content}</S.QuestionText>
-      </S.QuizCard>
+      <S.QuizViewport>
+        <S.QuizContent>
+          <S.QuizCard>
+            <S.QuestionText><span>Q.</span> {currentQuestion.content}</S.QuestionText>
+          </S.QuizCard>
 
-      <S.OptionList>
-        {currentQuestion.choices.map(choice => (
-          <AnswerOptionButton
-            key={choice.id}
-            id={choice.id}
-            content={choice.content}
-            selectedId={selectedChoiceId}
-            onSelect={handleSelectChoice}
-          />
-        ))}
-      </S.OptionList>
+          <S.OptionList>
+            {currentQuestion.choices.map(choice => (
+              <AnswerOptionButton
+                key={choice.id}
+                id={choice.id}
+                content={choice.content}
+                selectedId={selectedChoiceId}
+                onSelect={handleSelectChoice}
+              />
+            ))}
+          </S.OptionList>
+        </S.QuizContent>
+      </S.QuizViewport>
 
       <S.FooterActions>
         <S.PrimaryActionButton

--- a/apps/mac/src/renderer/src/features/chapter/ui/AnswerOptionButton.style.ts
+++ b/apps/mac/src/renderer/src/features/chapter/ui/AnswerOptionButton.style.ts
@@ -3,7 +3,7 @@ import { font } from "@clash/design-tokens/font";
 import { palette } from "@clash/design-tokens/theme";
 
 const optionSurface = "rgba(255, 255, 255, 0.05)";
-const optionSurfaceSelected = "rgba(239,88,89,0.12)";
+const optionSurfaceSelected = "rgba(255,202,202,0.12)";
 const optionBorder = "rgba(255, 255, 255, 0.08)";
 
 export const AnswerOption = styled.button<{ $selected: boolean }>`
@@ -21,15 +21,6 @@ export const AnswerOption = styled.button<{ $selected: boolean }>`
   text-align: center;
   line-height: 1.45;
   cursor: pointer;
-  transition:
-    border-color 0.18s ease,
-    box-shadow 0.18s ease,
-    transform 0.18s ease;
-
-  &:hover {
-    border-color: ${({ theme }) => theme.primary.normal};
-    transform: translateY(-1px);
-  }
 
   &:disabled {
     color: ${palette.neutral[70]};


### PR DESCRIPTION
## 변경사항

- 로드맵 섹션/챕터 진행도를 더미 값이 아닌 실제 완료 데이터 기준으로 반영했습니다.
- 큰 화면에서도 챕터 로드맵이 잘리지 않도록 스크롤 가능한 캔버스로 정리하고, 미션 패널을 전체 화면 오버레이로 변경했습니다.
- 챕터 상세 패널, 퀴즈, 결과, 로딩 UI를 전반적으로 다듬어 다크 테마에 맞게 정리했습니다.
- 긴 문제/해설에서도 자연스럽게 스크롤되도록 개선하고, 퀴즈 재도전 및 결과 흐름을 포함한 미션 인터랙션을 정리했습니다.

## 관련 이슈

Closes #408

## 스크린샷/동영상

- 로드맵 섹션/챕터 화면
- 미션 상세 패널
- 퀴즈/정답 결과 화면

## 추가 컨텍스트

- `pnpm --filter @clash/mac typecheck` 통과
- 리뷰는 `진행도 데이터 연동 -> 로드맵 캔버스/패널 레이아웃 -> 퀴즈/결과 UI` 순서로 보시면 됩니다.
