### PR TITLE
fix: when change group record date time passes/#533

### DIFF
--- a/apps/mac/src/renderer/src/features/record/model/useGroupRealtimeActivity.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useGroupRealtimeActivity.ts
@@ -6,7 +6,7 @@ import { useLiveRecordStudyTime } from "./useLiveRecordStudyTime";
 export const useGroupRealtimeActivity = (groupId: number | null, selectedDate?: string) => {
   const { data: myProfile } = useGetMyProfile();
   const myUserId = myProfile?.id ?? null;
-  const { totalStudyTime, isStudying } = useLiveRecordStudyTime(selectedDate);
+  const { totalStudyTime, isLoading, isStudying } = useLiveRecordStudyTime(selectedDate);
   const { groupMembers, activeStudyingCount, incrementStudyingMembers } = useGroupMembersActivity(
     groupId,
     myUserId,
@@ -23,6 +23,7 @@ export const useGroupRealtimeActivity = (groupId: number | null, selectedDate?: 
 
   return {
     totalStudyTime,
+    isLoading,
     isStudying,
     groupMembers,
     activeStudyingCount,

--- a/apps/mac/src/renderer/src/features/record/model/useLiveRecordStudyTime.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useLiveRecordStudyTime.ts
@@ -3,11 +3,12 @@ import { useRecordTodayQuery } from "@/entities/record";
 import { useRecordStore } from "./recordStore";
 
 export const useLiveRecordStudyTime = (selectedDate?: string) => {
-  const { data: todayResponse } = useRecordTodayQuery(selectedDate);
+  const { data: todayResponse, isPending } = useRecordTodayQuery(selectedDate);
   const activeSessionType = useRecordStore(state => state.activeSessionType);
   const baseStudyTime = useRecordStore(state => state.baseStudyTime);
   const currentStudyTime = useRecordStore(state => state.currentStudyTime);
   const isTodaySelected = selectedDate === undefined;
+  const isLoading = !isTodaySelected && isPending && todayResponse === undefined;
 
   const hasServerActiveSession = useMemo(() => {
     if (!todayResponse?.success || !todayResponse.data) {
@@ -31,6 +32,7 @@ export const useLiveRecordStudyTime = (selectedDate?: string) => {
 
   return {
     totalStudyTime,
+    isLoading,
     isStudying: hasServerActiveSession || (isTodaySelected && activeSessionType !== null),
   };
 };

--- a/apps/mac/src/renderer/src/features/record/ui/group/Group.style.ts
+++ b/apps/mac/src/renderer/src/features/record/ui/group/Group.style.ts
@@ -81,9 +81,10 @@ export const MyStudyFireIcon = styled(Fire)`
   height: 4rem;
 `;
 
-export const MyStudyTime = styled.span<{ $isActive: boolean }>`
+export const MyStudyTime = styled.span<{ $isActive: boolean; $loading?: boolean }>`
   ${font.headline1.medium}
   color: ${({ $isActive, theme }) => ($isActive ? theme.primary.normal : theme.label.assistive)};
+  opacity: ${({ $loading }) => ($loading ? 0.48 : 1)};
 `;
 
 export const GroupInfoRow = styled.div`

--- a/apps/mac/src/renderer/src/features/record/ui/group/Group.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/group/Group.tsx
@@ -23,8 +23,9 @@ export const Group = ({
   onResetToToday,
   canGoNextDate,
 }: GroupProps) => {
-  const { totalStudyTime, isStudying, groupMembers, activeStudyingCount } =
+  const { totalStudyTime, isLoading, isStudying, groupMembers, activeStudyingCount } =
     useGroupRealtimeActivity(currentGroup?.id ?? null, selectedDate);
+  const displayStudyTime = isLoading ? "--:--:--" : formatTime(totalStudyTime);
 
   return (
     <>
@@ -57,7 +58,9 @@ export const Group = ({
                 </S.HeaderTimerSection>
                 <S.MyStudySummary $isActive={isStudying}>
                   <S.MyStudyFireIcon />
-                  <S.MyStudyTime $isActive={isStudying}>{formatTime(totalStudyTime)}</S.MyStudyTime>
+                  <S.MyStudyTime $isActive={isStudying} $loading={isLoading}>
+                    {displayStudyTime}
+                  </S.MyStudyTime>
                 </S.MyStudySummary>
               </S.HeaderTimer>
               <S.GroupBodySection>

--- a/apps/mac/src/renderer/src/features/record/ui/timer/Timer.style.ts
+++ b/apps/mac/src/renderer/src/features/record/ui/timer/Timer.style.ts
@@ -76,11 +76,12 @@ export const TimeBox = styled.div`
   gap: 0.625rem;
 `;
 
-export const Time = styled.span`
+export const Time = styled.span<{ $loading?: boolean }>`
   display: inline-block;
   min-width: 8ch;
   text-align: center;
   color: ${({ theme }) => theme.label.alternative};
+  opacity: ${({ $loading }) => ($loading ? 0.48 : 1)};
   ${font.display1.medium};
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";

--- a/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
@@ -25,12 +25,13 @@ export const Timer = ({
   nonTodayStopBehavior = "disable",
 }: TimerProps) => {
   const { activeSessionType, stop } = useRecordStore();
-  const { totalStudyTime } = useLiveRecordStudyTime(selectedDate);
+  const { totalStudyTime, isLoading } = useLiveRecordStudyTime(selectedDate);
   const isTodaySelected = selectedDate === undefined;
   const isPreviousDateEnabled = typeof onPreviousDate === "function";
   const isNextDateEnabled = typeof onNextDate === "function" && canGoNextDate;
   const isStopButtonDisabled = !isTodaySelected;
   const shouldHideStopButton = nonTodayStopBehavior === "hide" && !isTodaySelected;
+  const displayTime = isLoading ? "--:--:--" : formatTime(totalStudyTime);
   const stopButton =
     activeSessionType !== null && !shouldHideStopButton ? (
       <S.PlayButton
@@ -81,7 +82,7 @@ export const Timer = ({
       </S.DateBox>
       <S.TimeBox>
         {stopButtonPosition === "LEFT" && stopButton}
-        <S.Time>{formatTime(totalStudyTime)}</S.Time>
+        <S.Time $loading={isLoading}>{displayTime}</S.Time>
         {stopButtonPosition === "RIGHT" && stopButton}
       </S.TimeBox>
     </>


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->


- 그룹 스터디에서 날짜를 빠르게 이동할 때 선택되지 않은 날짜의 시간까지 계속 흐르던 문제를 수정했습니다.
- 날짜 전환 중 타이머가 00:00:00으로 튀지 않도록 --:--:-- 로딩 표시로 바꿔 UX를 개선했습니다.

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #533

## 스크린샷/동영상

<!-- UI 변경이 있는 경우에만 추가해주세요 -->

https://github.com/user-attachments/assets/08f4f52b-d18b-46e6-9c9b-7ff6c8652ed9


## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
