### PR TITLE
fix: unfinished-chapter-issue/#585

### DIFF
--- a/apps/mac/src/renderer/src/entities/roadmap/chapter/model/chapter.types.ts
+++ b/apps/mac/src/renderer/src/entities/roadmap/chapter/model/chapter.types.ts
@@ -12,6 +12,7 @@ export interface SectionChapter {
 export interface GetSectionDetailsResponse {
   sectionId: number;
   sectionTitle: string;
+  completed: true;
   totalChapters: number;
   currentChapterId: number | null;
   currentOrderIndex: number | null;

--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
@@ -39,11 +39,11 @@ interface QuizPanelContentProps {
 }
 
 const QuizPanelContent = ({
-  mission,
-  stageTitle,
-  onBackToOverview,
-  onMissionComplete,
-}: QuizPanelContentProps) => {
+                            mission,
+                            stageTitle,
+                            onBackToOverview,
+                            onMissionComplete,
+                          }: QuizPanelContentProps) => {
   const {
     state,
     error,
@@ -284,20 +284,20 @@ const QuizPanelContent = ({
 };
 
 export const MissionContainer = ({
-  isOpen,
-  currentStage,
-  currentMission,
-  currentMissionStageTitle,
-  description,
-  isLoading,
-  isSolveDisabled,
-  studyMaterialUrl,
-  onClose,
-  onSolve,
-  onBackToOverview,
-  onMissionComplete,
-  isFinishedSection
-}: MissionContainerProps) => {
+                                   isOpen,
+                                   currentStage,
+                                   currentMission,
+                                   currentMissionStageTitle,
+                                   description,
+                                   isLoading,
+                                   isSolveDisabled,
+                                   studyMaterialUrl,
+                                   onClose,
+                                   onSolve,
+                                   onBackToOverview,
+                                   onMissionComplete,
+                                   isFinishedSection
+                                 }: MissionContainerProps) => {
   const [isClosing, setIsClosing] = useState(false);
   const [studyMaterialError, setStudyMaterialError] = useState<string | null>(null);
   const closeTimeoutRef = useRef<number | null>(null);
@@ -350,10 +350,10 @@ export const MissionContainer = ({
   const isCompletedStage = isFinishedSection ||
     (currentStage.totalMissions > 0 && currentStage.currentProgress >= currentStage.totalMissions);
   const hasStudyMaterial = Boolean(studyMaterialUrl?.trim());
-  const processedCurrentMission: Mission | null = {
+  const processedCurrentMission: Mission | null = currentMission ? {
     ...currentMission,
-    completed: isFinishedSection ? true : currentMission?.completed
-  };
+    completed: (isFinishedSection ? true : currentMission?.completed) ?? false
+  } : null;
 
   return (
     <SidePanel
@@ -380,7 +380,7 @@ export const MissionContainer = ({
 
         {currentMission ? (
           <QuizPanelContent
-            mission={processedCurrentMission}
+            mission={processedCurrentMission ?? currentMission}
             stageTitle={displayStageTitle}
             onBackToOverview={onBackToOverview}
             onMissionComplete={onMissionComplete}

--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
@@ -28,6 +28,7 @@ interface MissionContainerProps {
   onSolve: () => void;
   onBackToOverview: () => void;
   onMissionComplete?: (missionId: number) => void;
+  isFinishedSection: boolean;
 }
 
 interface QuizPanelContentProps {
@@ -295,6 +296,7 @@ export const MissionContainer = ({
   onSolve,
   onBackToOverview,
   onMissionComplete,
+  isFinishedSection
 }: MissionContainerProps) => {
   const [isClosing, setIsClosing] = useState(false);
   const [studyMaterialError, setStudyMaterialError] = useState<string | null>(null);
@@ -345,9 +347,13 @@ export const MissionContainer = ({
   const descriptionText = isLoading
     ? "챕터 정보를 불러오는 중입니다."
     : description?.trim() || "이 챕터에 대한 설명이 아직 준비되지 않았습니다.";
-  const isCompletedStage =
-    currentStage.totalMissions > 0 && currentStage.currentProgress >= currentStage.totalMissions;
+  const isCompletedStage = isFinishedSection ||
+    (currentStage.totalMissions > 0 && currentStage.currentProgress >= currentStage.totalMissions);
   const hasStudyMaterial = Boolean(studyMaterialUrl?.trim());
+  const processedCurrentMission: Mission | null = {
+    ...currentMission,
+    completed: isFinishedSection ? true : currentMission?.completed
+  };
 
   return (
     <SidePanel
@@ -374,7 +380,7 @@ export const MissionContainer = ({
 
         {currentMission ? (
           <QuizPanelContent
-            mission={currentMission}
+            mission={processedCurrentMission}
             stageTitle={displayStageTitle}
             onBackToOverview={onBackToOverview}
             onMissionComplete={onMissionComplete}

--- a/apps/mac/src/renderer/src/features/chapter/components/RoadmapNode.tsx
+++ b/apps/mac/src/renderer/src/features/chapter/components/RoadmapNode.tsx
@@ -37,6 +37,7 @@ export const RoadmapNode = ({ node, onClick }: RoadmapNodeProps) => {
     <S.NodeGroup
       onClick={onClick}
       data-roadmap-node-id={node.id}
+      data-roadmap-node-order-index={node.orderIndex}
       data-roadmap-node-status={node.status}
     >
       <S.NodeCircle cx={node.x} cy={node.y} r={NODE_RADIUS} $status={node.status} />

--- a/apps/mac/src/renderer/src/features/chapter/model/useChapter.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useChapter.ts
@@ -52,7 +52,11 @@ const resetSectionDetails = (
 export const useChapter = (sectionId: number) => {
   const queryClient = useQueryClient();
   const domain = useChapterDomain(sectionId);
-  const view = useChapterView({ loading: domain.loading, sectionId });
+  const view = useChapterView({
+    loading: domain.loading,
+    sectionId,
+    sectionCompleted: domain.sectionCompleted,
+  });
   const resetChapterMutation = useResetChapterMutation();
   const currentStageId = domain.currentStageId;
   const [resetOnOpenState, setResetOnOpenState] = useState({
@@ -230,6 +234,7 @@ export const useChapter = (sectionId: number) => {
       currentStageMissionsLoading: isCurrentStageInitialLoading,
       currentStageDetailsLoading: isCurrentStageInitialLoading,
       currentStageDetailsError,
+      sectionCompleted: domain.sectionCompleted,
       sectionTitle: domain.sectionTitle,
       completedChapters: domain.completedChapters,
       totalChapters: domain.totalChapters,

--- a/apps/mac/src/renderer/src/features/chapter/model/useChapterDomain.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useChapterDomain.ts
@@ -192,6 +192,7 @@ export const useChapterDomain = (sectionId: number) => {
     currentStageId,
     setCurrentStageId,
     currentStage,
+    sectionCompleted: Boolean(sectionDetails?.completed),
     sectionTitle: sectionDetails?.sectionTitle ?? "",
     completedChapters,
     totalChapters,

--- a/apps/mac/src/renderer/src/features/chapter/model/useChapterView.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useChapterView.ts
@@ -5,6 +5,7 @@ import { useDragScroll } from "@/shared/lib/useDragScroll";
 type UseChapterViewParams = {
   loading: boolean;
   sectionId: number;
+  sectionCompleted: boolean;
 };
 
 const createInitialViewState = (sectionId: number) => ({
@@ -14,11 +15,58 @@ const createInitialViewState = (sectionId: number) => ({
   missionModalOpen: false,
 });
 
-export const useChapterView = ({ loading, sectionId }: UseChapterViewParams) => {
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const getNodeOrderIndex = (node: SVGGElement) => {
+  const value = Number(node.dataset.roadmapNodeOrderIndex);
+
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+};
+
+const getLastRoadmapNode = (container: HTMLDivElement) => {
+  const nodes = Array.from(
+    container.querySelectorAll<SVGGElement>("[data-roadmap-node-order-index]")
+  );
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  return nodes.reduce((latestNode, candidate) =>
+    getNodeOrderIndex(candidate) > getNodeOrderIndex(latestNode) ? candidate : latestNode
+  );
+};
+
+const scrollNodeIntoView = (container: HTMLDivElement, targetNode: SVGGElement) => {
+  const containerRect = container.getBoundingClientRect();
+  const nodeRect = targetNode.getBoundingClientRect();
+  const nodeCenterX = nodeRect.left - containerRect.left + container.scrollLeft + nodeRect.width / 2;
+  const nodeCenterY = nodeRect.top - containerRect.top + container.scrollTop + nodeRect.height / 2;
+
+  const targetLeft = clamp(
+    nodeCenterX - container.clientWidth * 0.62,
+    0,
+    Math.max(container.scrollWidth - container.clientWidth, 0)
+  );
+  const targetTop = clamp(
+    nodeCenterY - container.clientHeight * 0.72,
+    0,
+    Math.max(container.scrollHeight - container.clientHeight, 0)
+  );
+
+  container.scrollTo({
+    left: targetLeft,
+    top: targetTop,
+  });
+};
+
+export const useChapterView = ({
+  loading,
+  sectionId,
+  sectionCompleted,
+}: UseChapterViewParams) => {
   const chapterRef = useRef<HTMLDivElement>(null);
   const chapterScrollProps = useDragScroll<HTMLDivElement>();
-
-  const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
   const [viewState, setViewState] = useState(() => createInitialViewState(sectionId));
 
@@ -79,11 +127,10 @@ export const useChapterView = ({ loading, sectionId }: UseChapterViewParams) => 
         if (!chapterRef.current) return;
 
         const container = chapterRef.current;
-        const currentNode = container.querySelector<SVGGElement>(
-          '[data-roadmap-node-status="current"]'
-        );
+        const currentNode = container.querySelector<SVGGElement>('[data-roadmap-node-status="current"]');
+        const targetNode = currentNode ?? (sectionCompleted ? getLastRoadmapNode(container) : null);
 
-        if (!currentNode) {
+        if (!targetNode) {
           container.scrollTo({
             left: container.scrollWidth,
             top: container.scrollHeight,
@@ -91,28 +138,7 @@ export const useChapterView = ({ loading, sectionId }: UseChapterViewParams) => 
           return;
         }
 
-        const containerRect = container.getBoundingClientRect();
-        const nodeRect = currentNode.getBoundingClientRect();
-        const nodeCenterX =
-          nodeRect.left - containerRect.left + container.scrollLeft + nodeRect.width / 2;
-        const nodeCenterY =
-          nodeRect.top - containerRect.top + container.scrollTop + nodeRect.height / 2;
-
-        const targetLeft = clamp(
-          nodeCenterX - container.clientWidth * 0.62,
-          0,
-          Math.max(container.scrollWidth - container.clientWidth, 0)
-        );
-        const targetTop = clamp(
-          nodeCenterY - container.clientHeight * 0.72,
-          0,
-          Math.max(container.scrollHeight - container.clientHeight, 0)
-        );
-
-        container.scrollTo({
-          left: targetLeft,
-          top: targetTop,
-        });
+        scrollNodeIntoView(container, targetNode);
       });
     });
 
@@ -120,7 +146,7 @@ export const useChapterView = ({ loading, sectionId }: UseChapterViewParams) => 
       window.cancelAnimationFrame(frame);
       window.cancelAnimationFrame(secondFrame);
     };
-  }, [loading, sectionId]);
+  }, [loading, sectionCompleted, sectionId]);
 
   return {
     chapterRef,

--- a/apps/mac/src/renderer/src/features/chapter/model/useQuiz.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useQuiz.ts
@@ -9,7 +9,6 @@ import {
   useSubmitAnswerMutation,
 } from "@/entities/roadmap/chapter";
 import { getErrorMessage } from "@/shared/lib";
-import { useSectionDetailsQuery } from "@/entities/roadmap/chapter/api/query/useSectionDetails.query";
 
 type QuizState = {
   currentIndex: number;

--- a/apps/mac/src/renderer/src/features/chapter/model/useQuiz.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useQuiz.ts
@@ -9,6 +9,7 @@ import {
   useSubmitAnswerMutation,
 } from "@/entities/roadmap/chapter";
 import { getErrorMessage } from "@/shared/lib";
+import { useSectionDetailsQuery } from "@/entities/roadmap/chapter/api/query/useSectionDetails.query";
 
 type QuizState = {
   currentIndex: number;

--- a/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
+++ b/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo } from "react";
 import { useGetMyProfile } from "@/entities/user";
 import { useMajorSectionQuery } from "@/entities/roadmap/section/api/query/useMajorSection.query";
 import { MissionContainer } from "@/features/chapter/components/MissionContainer";
+import { useSectionDetailsQuery } from "@/entities/roadmap/chapter/api/query/useSectionDetails.query";
 
 export const ChapterPage = () => {
   const { sectionId } = useParams<{ sectionId: string }>();
@@ -20,6 +21,8 @@ export const ChapterPage = () => {
   const major = myProfile?.major as MajorEnum;
 
   const { data: sectionData } = useMajorSectionQuery(major);
+  const { data: sectionDetailData } = useSectionDetailsQuery(+(sectionId ?? 0));
+  const roadmapNodes = domain.roadmapNodes.map(n => ({...n, status: sectionDetailData?.completed ? "completed" : n.status}));
 
   const navigate = useNavigate();
 
@@ -95,9 +98,9 @@ export const ChapterPage = () => {
       <S.ChapterScrollable ref={chapterRef} {...chapterScrollProps}>
         <S.ChapterCanvas>
           <S.RoadmapStageArea>
-            {domain.roadmapNodes.length > 0 ? (
+            {roadmapNodes.length > 0 ? (
               <S.RoadmapWrapper>
-                <Roadmap nodes={domain.roadmapNodes} onSelectStage={handlers.handleSelectStage} />
+                <Roadmap nodes={roadmapNodes} onSelectStage={handlers.handleSelectStage} />
               </S.RoadmapWrapper>
             ) : (
               <S.EmptyRoadmapMessage>아직 등록된 챕터가 없습니다.</S.EmptyRoadmapMessage>
@@ -107,7 +110,7 @@ export const ChapterPage = () => {
       </S.ChapterScrollable>
 
       <ChapterRanking page="chapter" />
-      <SectionProgress completed={domain.completedChapters} total={domain.totalChapters} />
+      <SectionProgress completed={sectionDetailData?.completed ? domain.completedChapters + 1 : domain.completedChapters} total={domain.totalChapters} />
 
       <Link to="/roadmap">
         <S.PreviousBox>
@@ -156,6 +159,7 @@ export const ChapterPage = () => {
           onBackToOverview={handlers.handleCloseQuizModal}
           onSolve={handlers.handleStartCurrentStageMission}
           onMissionComplete={handlers.handleMissionComplete}
+          isFinishedSection={Boolean(sectionDetailData?.completed)}
         />
       )}
     </S.ChapterContainer>

--- a/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
+++ b/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
@@ -9,7 +9,6 @@ import { useEffect, useMemo } from "react";
 import { useGetMyProfile } from "@/entities/user";
 import { useMajorSectionQuery } from "@/entities/roadmap/section/api/query/useMajorSection.query";
 import { MissionContainer } from "@/features/chapter/components/MissionContainer";
-import { useSectionDetailsQuery } from "@/entities/roadmap/chapter/api/query/useSectionDetails.query";
 
 export const ChapterPage = () => {
   const { sectionId } = useParams<{ sectionId: string }>();
@@ -21,8 +20,10 @@ export const ChapterPage = () => {
   const major = myProfile?.major as MajorEnum;
 
   const { data: sectionData } = useMajorSectionQuery(major);
-  const { data: sectionDetailData } = useSectionDetailsQuery(+(sectionId ?? 0));
-  const roadmapNodes = domain.roadmapNodes.map(n => ({...n, status: sectionDetailData?.completed ? "completed" : n.status}));
+  const roadmapNodes = domain.roadmapNodes.map(n => ({
+    ...n,
+    status: domain.sectionCompleted ? "completed" : n.status,
+  }));
 
   const navigate = useNavigate();
 
@@ -110,7 +111,10 @@ export const ChapterPage = () => {
       </S.ChapterScrollable>
 
       <ChapterRanking page="chapter" />
-      <SectionProgress completed={sectionDetailData?.completed ? domain.completedChapters + 1 : domain.completedChapters} total={domain.totalChapters} />
+      <SectionProgress
+        completed={domain.sectionCompleted ? domain.completedChapters + 1 : domain.completedChapters}
+        total={domain.totalChapters}
+      />
 
       <Link to="/roadmap">
         <S.PreviousBox>
@@ -159,7 +163,7 @@ export const ChapterPage = () => {
           onBackToOverview={handlers.handleCloseQuizModal}
           onSolve={handlers.handleStartCurrentStageMission}
           onMissionComplete={handlers.handleMissionComplete}
-          isFinishedSection={Boolean(sectionDetailData?.completed)}
+          isFinishedSection={domain.sectionCompleted}
         />
       )}
     </S.ChapterContainer>


### PR DESCRIPTION
## 변경사항

<!-- 무엇을 변경했는지 간단히 작성해주세요 -->

- 로드맵 페이지의 ChapterPage에서 useSectionDetails 쿼리를 호출해 섹션의 클리어 여부를 확인
- 이후 MissionContainer, QuizPanel에서도 클리어된 섹션의 챕터면 완료된 UI를 표시하도록 props 전해줌.

## 관련 이슈

<!-- 관련 이슈가 있다면 "Closes #이슈번호" 형식으로 작성 (자동으로 이슈가 닫힙니다) -->

Closes #585 

## 스크린샷/동영상

<!-- UI 변경이 있는 경우에만 추가해주세요 -->
<img width="1227" height="799" alt="스크린샷 2026-04-13 오후 9 49 00" src="https://github.com/user-attachments/assets/0106d5fb-2d5e-41fd-8d2c-576de3094b5d" />


## 추가 컨텍스트

<!-- 리뷰어가 알아야 할 특별한 사항이나 고민했던 부분 (선택사항) -->
ChapterPage.tsx는 FSD가 심각하게 위반되어 있어 추후 다시 리팩터링을 진행할 필요가 있습니다.