### PR TITLE
refactor: state management/#620

### DIFF
--- a/apps/mac/src/renderer/src/app/layouts/main/MainLayout.tsx
+++ b/apps/mac/src/renderer/src/app/layouts/main/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { AttendanceDialog, useAttendanceDialog } from "@/features/attendance";
-import { useDailyRefresh, useRealtimeSync } from "@/features/app-monitor";
+import { useAppMonitor, useDailyRefresh, useRealtimeSync } from "@/features/app-monitor";
 import { GlobalAnnouncementDialog } from "@/features/announcement";
 import { useNoticePushNotification } from "@/features/notice";
 import { GitHubGuard } from "@/widgets/github-guard";
@@ -14,7 +14,8 @@ export const MainLayout = () => {
   const mainContentRef = useRef<HTMLElement>(null);
   const { pathname } = useLocation();
   const attendanceDialog = useAttendanceDialog();
-  useRealtimeSync();
+  const appMonitor = useAppMonitor();
+  useRealtimeSync(appMonitor.frontmostMonitoredApp !== null);
   useDailyRefresh();
   useNoticePushNotification();
 
@@ -34,7 +35,7 @@ export const MainLayout = () => {
         isAttendancePending={attendanceDialog.isAttendancePending}
       />
       <S.ContentWrapper>
-        <Sidebar isOpen={isSidebarOpen} />
+        <Sidebar isOpen={isSidebarOpen} appMonitor={appMonitor} />
         <S.MainContent ref={mainContentRef}>
           <Outlet />
         </S.MainContent>

--- a/apps/mac/src/renderer/src/app/session/registerSessionResetHandlers.ts
+++ b/apps/mac/src/renderer/src/app/session/registerSessionResetHandlers.ts
@@ -1,0 +1,8 @@
+import { resetRecordStore } from "@/features/record";
+import { registerSessionResetHandler } from "@/shared/lib";
+
+export const registerSessionResetHandlers = () => {
+  registerSessionResetHandler("record-store", () => {
+    resetRecordStore();
+  });
+};

--- a/apps/mac/src/renderer/src/entities/attendance/api/mutation/useAttendance.mutation.ts
+++ b/apps/mac/src/renderer/src/entities/attendance/api/mutation/useAttendance.mutation.ts
@@ -10,12 +10,8 @@ export const useMarkAttendanceMutation = () => {
       const response = await attendanceApi.markAttendance();
       return response.data;
     },
-    onSettled: (_data, error) => {
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: attendanceQueryKeys.all });
-
-      if (!error) {
-        void queryClient.invalidateQueries({ queryKey: ["user"] });
-      }
     },
   });
 };

--- a/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useActive.query.ts
+++ b/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useActive.query.ts
@@ -3,7 +3,8 @@ import { activeApi } from "../activeApi";
 import type { CategoryType } from "../../../../model/rival-competition/compareRivals.types";
 
 export const activeQueryKeys = {
-  active: (category: CategoryType) => ["active", category] as const,
+  all: ["active"] as const,
+  active: (category: CategoryType) => [...activeQueryKeys.all, category] as const,
 };
 
 export const useActiveQuery = (category: CategoryType) => {

--- a/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useCompare.query.ts
+++ b/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useCompare.query.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { compareApi } from "../compareApi";
 
 export const compareQueryKeys = {
+  all: ["compare"] as const,
   compare: ["compare"] as const,
 };
 

--- a/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useTransition.query.ts
+++ b/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/query/useTransition.query.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { transitionApi } from "../transitionApi";
 
 export const transitionQueryKeys = {
+  all: ["transition"] as const,
   transition: ["transition"] as const,
 };
 

--- a/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/useMyCompetitionQuery.query.ts
+++ b/apps/mac/src/renderer/src/entities/competition/api/my-competition/api/useMyCompetitionQuery.query.ts
@@ -6,16 +6,25 @@ import type {
   MyCompareRequest,
 } from "../../../model/my-competition/myCompetition.types";
 
+export const myCompetitionQueryKeys = {
+  compares: ["myCompare"] as const,
+  compare: (standard: MyCompareRequest["standard"]) =>
+    [...myCompetitionQueryKeys.compares, standard] as const,
+  growthRates: ["myGrowthRate"] as const,
+  growthRate: (category: AnalyzeCategory, period: GrowthRateStandard) =>
+    [...myCompetitionQueryKeys.growthRates, category, period] as const,
+};
+
 export const useMyCompareQuery = (standard: MyCompareRequest["standard"]) => {
   return useQuery({
-    queryKey: ["myCompare", standard],
+    queryKey: myCompetitionQueryKeys.compare(standard),
     queryFn: () => myCompetitionApi.getMyCompare({ standard }),
   });
 };
 
 export const useMyGrowthRateQuery = (category: AnalyzeCategory, period: GrowthRateStandard) => {
   return useQuery({
-    queryKey: ["myGrowthRate", category, period],
+    queryKey: myCompetitionQueryKeys.growthRate(category, period),
     queryFn: () => myCompetitionApi.getMyGrowthRate({ category, period }),
     enabled: !!category && !!period,
   });

--- a/apps/mac/src/renderer/src/entities/competition/api/rival-competition/api/query/useBattle.query.ts
+++ b/apps/mac/src/renderer/src/entities/competition/api/rival-competition/api/query/useBattle.query.ts
@@ -3,7 +3,6 @@ import { battleApi } from "../battleApi";
 import type { AnalyzeBattleRequest } from "../../../../model/rival-competition/battle.types";
 
 export const battleQueryKeys = {
-  all: ["battle"] as const,
   info: ["battleInfo"] as const,
   details: ["battleDetail"] as const,
   detail: (id: number) => [...battleQueryKeys.details, id] as const,

--- a/apps/mac/src/renderer/src/entities/competition/index.ts
+++ b/apps/mac/src/renderer/src/entities/competition/index.ts
@@ -6,6 +6,7 @@ export {
   useTransitionQuery,
 } from "./api/my-competition/api/query/useTransition.query";
 export {
+  myCompetitionQueryKeys,
   useMyGrowthRateQuery,
   useMyCompareQuery,
 } from "./api/my-competition/api/useMyCompetitionQuery.query";

--- a/apps/mac/src/renderer/src/entities/profile/api/query/useEquipItem.mutation.ts
+++ b/apps/mac/src/renderer/src/entities/profile/api/query/useEquipItem.mutation.ts
@@ -14,10 +14,7 @@ export const useEquipItemMutation = () => {
     mutationFn: ({ productId, shouldUnequip }: ItemEquipMutationRequest) =>
       shouldUnequip ? itemEquipApi.unequipItem(productId) : itemEquipApi.equipItem(productId),
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["user"] }),
-        queryClient.invalidateQueries({ queryKey: ownedItemsQueryKeys.all }),
-      ]);
+      await queryClient.invalidateQueries({ queryKey: ownedItemsQueryKeys.all });
     },
   });
 };

--- a/apps/mac/src/renderer/src/entities/profile/api/query/useProfileGithubDetail.query.ts
+++ b/apps/mac/src/renderer/src/entities/profile/api/query/useProfileGithubDetail.query.ts
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { profileGithubDetailApi } from "../profileGithubDetailApi";
 
+export const profileGithubDetailQueryKeys = {
+  all: ["profileGithubDetail"] as const,
+  detail: (date: string | null) => [...profileGithubDetailQueryKeys.all, date] as const,
+};
+
 export const useProfileGithubDetailQuery = (date: string | null) => {
   const { data, isError, isFetching, isLoading, isPlaceholderData } = useQuery({
-    queryKey: ["profileGithubDetail", date],
+    queryKey: profileGithubDetailQueryKeys.detail(date),
     queryFn: () => {
       if (!date) throw new Error("잔디를 선택하지 않았습니다.");
       return profileGithubDetailApi.getProfileGithubDetail({ date });

--- a/apps/mac/src/renderer/src/entities/profile/index.ts
+++ b/apps/mac/src/renderer/src/entities/profile/index.ts
@@ -1,5 +1,8 @@
 export { useEquipItemMutation } from "./api/query/useEquipItem.mutation";
-export { useOwnedItemsQuery } from "./api/query/useOwnedItems.query";
-export { useProfileGithubDetailQuery } from "./api/query/useProfileGithubDetail.query";
+export { ownedItemsQueryKeys, useOwnedItemsQuery } from "./api/query/useOwnedItems.query";
+export {
+  profileGithubDetailQueryKeys,
+  useProfileGithubDetailQuery,
+} from "./api/query/useProfileGithubDetail.query";
 export { OwnedItemCategory } from "./model/ownedItems.types";
 export type { OwnedItem, OwnedItemDisplayCategory } from "./model/ownedItems.types";

--- a/apps/mac/src/renderer/src/entities/roadmap/chapter/chapter-ranking/api/query/useChapterRanking.query.ts
+++ b/apps/mac/src/renderer/src/entities/roadmap/chapter/chapter-ranking/api/query/useChapterRanking.query.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { rankingApi } from "../chapterRankingApi";
 
 export const chapterRankingQueryKeys = {
+  all: ["chapterRankings"] as const,
   list: ["chapterRankings"] as const,
 };
 

--- a/apps/mac/src/renderer/src/entities/roadmap/section/api/query/useMajorSection.query.ts
+++ b/apps/mac/src/renderer/src/entities/roadmap/section/api/query/useMajorSection.query.ts
@@ -3,7 +3,8 @@ import { MajorEnum, type getAllSectionsResponse } from "../../model/section.type
 import { sectionApi } from "../sectionApi";
 
 export const sectionQueryKeys = {
-  major: (major: MajorEnum) => ["sections", "major", major] as const,
+  all: ["sections"] as const,
+  major: (major: MajorEnum) => [...sectionQueryKeys.all, "major", major] as const,
 };
 
 export const useMajorSectionQuery = (major: MajorEnum) => {

--- a/apps/mac/src/renderer/src/entities/roadmap/section/preview/api/query/useSectionPreview.query.ts
+++ b/apps/mac/src/renderer/src/entities/roadmap/section/preview/api/query/useSectionPreview.query.ts
@@ -3,7 +3,8 @@ import { previewApi } from "../previewApi";
 import type { GetSectionPreviewResponse } from "../../model/preview.types";
 
 export const previewQueryKeys = {
-  detail: (sectionId: number) => ["roadmap", "sectionPreview", sectionId] as const,
+  all: ["roadmap", "sectionPreview"] as const,
+  detail: (sectionId: number) => [...previewQueryKeys.all, sectionId] as const,
 };
 
 export const useSectionPreviewQuery = (sectionId: number) => {

--- a/apps/mac/src/renderer/src/entities/user/api/mutation/useProfileImage.mutation.ts
+++ b/apps/mac/src/renderer/src/entities/user/api/mutation/useProfileImage.mutation.ts
@@ -3,6 +3,7 @@ import { profileImageApi, uploadProfileImageToS3 } from "../profileImageApi";
 import type { GetMyProfileResponse } from "../authApi";
 import type { ApplyProfileImageRequest } from "../../model/profileImage.types";
 import { userQueryKeys } from "../../model/useGetMyProfile";
+import { captureSessionEpoch, isSessionEpochCurrent } from "@/shared/lib";
 
 export const useApplyProfileImageMutation = () => {
   return useMutation({
@@ -14,6 +15,7 @@ export const useUploadProfileImageMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    onMutate: () => ({ sessionEpoch: captureSessionEpoch() }),
     mutationFn: async (file: File) => {
       const fileName = file.name.trim().length > 0 ? file.name : `profile-${Date.now()}`;
       const contentType = file.type || "application/octet-stream";
@@ -40,7 +42,11 @@ export const useUploadProfileImageMutation = () => {
 
       return applyResponse.data?.profileImageUrl ?? uploadMetadata.fileUrl;
     },
-    onSuccess: async profileImageUrl => {
+    onSuccess: async (profileImageUrl, _file, context) => {
+      if (!isSessionEpochCurrent(context.sessionEpoch)) {
+        return;
+      }
+
       queryClient.setQueryData<GetMyProfileResponse | undefined>(userQueryKeys.profile, previous =>
         previous
           ? {

--- a/apps/mac/src/renderer/src/entities/user/model/useGetMyProfile.ts
+++ b/apps/mac/src/renderer/src/entities/user/model/useGetMyProfile.ts
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { authApi } from "../api/authApi";
 import type { GetMyProfileResponse } from "../api/authApi";
+import { SESSION_STORAGE_KEYS } from "@/shared/config/sessionStorage";
 
 export const userQueryKeys = {
   all: ["user"] as const,
   profile: ["user"] as const,
 };
 
-export const PROFILE_SYNC_UNTIL_KEY = "clash:home-ranking-user:profile-sync-until";
+export const PROFILE_SYNC_UNTIL_KEY = SESSION_STORAGE_KEYS.profileSyncUntil;
 const PROFILE_SYNC_WINDOW_MS = 3 * 60 * 1000;
 export const PROFILE_SYNC_INTERVAL_MS = 3000;
 

--- a/apps/mac/src/renderer/src/features/app-monitor/index.ts
+++ b/apps/mac/src/renderer/src/features/app-monitor/index.ts
@@ -1,3 +1,4 @@
 export { useAppMonitor } from "./model/useAppMonitor";
+export type { UseAppMonitorResult } from "./model/useAppMonitor";
 export { useDailyRefresh } from "./model/useDailyRefresh";
 export { useRealtimeSync } from "./model/useRealtimeSync";

--- a/apps/mac/src/renderer/src/features/app-monitor/model/invalidateRealtimeQueries.ts
+++ b/apps/mac/src/renderer/src/features/app-monitor/model/invalidateRealtimeQueries.ts
@@ -1,8 +1,18 @@
 import { attendanceQueryKeys } from "@/entities/attendance";
 import { announcementQueryKeys } from "@/entities/announcement";
+import {
+  activeQueryKeys,
+  battleQueryKeys,
+  compareQueryKeys,
+  compareRivalsQueryKeys,
+  myCompetitionQueryKeys,
+  transitionQueryKeys,
+} from "@/entities/competition";
 import { groupQueryKeys } from "@/entities/group";
 import { noticeQueryKeys } from "@/entities/notice";
 import { recordQueryKeys } from "@/entities/record";
+import { rivalQueryKeys } from "@/entities/rival";
+import { userQueryKeys } from "@/entities/user";
 import { queryClient } from "@/shared/lib";
 
 const invalidateAnnouncementQueries = async () => {
@@ -24,24 +34,26 @@ const invalidateGroupQueries = async () => {
 
 const invalidateCompeteQueries = async () => {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: ["myRivals"] }),
-    queryClient.invalidateQueries({ queryKey: ["compareRivals"] }),
-    queryClient.invalidateQueries({ queryKey: ["battleInfo"] }),
-    queryClient.invalidateQueries({ queryKey: ["battleDetail"] }),
-    queryClient.invalidateQueries({ queryKey: ["battleAnalyze"] }),
-    queryClient.invalidateQueries({ queryKey: ["battleList"] }),
-    queryClient.invalidateQueries({ queryKey: ["active"] }),
-    queryClient.invalidateQueries({ queryKey: ["compare"] }),
-    queryClient.invalidateQueries({ queryKey: ["transition"] }),
-    queryClient.invalidateQueries({ queryKey: ["myCompare"] }),
-    queryClient.invalidateQueries({ queryKey: ["myGrowthRate"] }),
-    queryClient.invalidateQueries({ queryKey: ["rivalList"] }),
+    queryClient.invalidateQueries({ queryKey: rivalQueryKeys.myRivals }),
+    queryClient.invalidateQueries({ queryKey: rivalQueryKeys.available }),
+    queryClient.invalidateQueries({ queryKey: rivalQueryKeys.requests }),
+    queryClient.invalidateQueries({ queryKey: compareRivalsQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.info }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.details }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.analyses }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.list }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.applications }),
+    queryClient.invalidateQueries({ queryKey: activeQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: compareQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: transitionQueryKeys.all }),
+    queryClient.invalidateQueries({ queryKey: myCompetitionQueryKeys.compares }),
+    queryClient.invalidateQueries({ queryKey: myCompetitionQueryKeys.growthRates }),
   ]);
 };
 
 const invalidateUserQueries = async () => {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: ["user"] }),
+    queryClient.invalidateQueries({ queryKey: userQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: noticeQueryKeys.all }),
   ]);
 };

--- a/apps/mac/src/renderer/src/features/app-monitor/model/useAppMonitor.ts
+++ b/apps/mac/src/renderer/src/features/app-monitor/model/useAppMonitor.ts
@@ -1,37 +1,13 @@
-import { useState, useEffect, useCallback } from "react";
-import { ActiveApp, MonitoringSession } from "@/entities/app-monitor";
+import { useEffect, useState } from "react";
+import type { ActiveApp } from "@/entities/app-monitor";
+
+const FRONTMOST_APP_POLL_MS = 2000;
 
 export const useAppMonitor = () => {
   const [activeApp, setActiveApp] = useState<ActiveApp | null>(null);
-  const [sessions, setSessions] = useState<MonitoringSession[]>([]);
-  const [isMonitoring, setIsMonitoring] = useState(false);
   const [hasInitialized, setHasInitialized] = useState(false);
-
-  const startMonitoring = useCallback(async () => {
-    try {
-      await window.api.startMonitoring();
-      setIsMonitoring(true);
-
-      // 초기 상태 로드
-      const currentApp = await window.api.getActiveApp();
-      setActiveApp(currentApp);
-
-      const currentSessions = await window.api.getSessions();
-      setSessions(currentSessions);
-    } catch (error) {
-      console.error("모니터링을 시작하는데 실패했습니다:", error);
-    }
-  }, []);
-
-  const stopMonitoring = useCallback(async () => {
-    try {
-      await window.api.stopMonitoring();
-      setIsMonitoring(false);
-      setActiveApp(null);
-    } catch (error) {
-      console.error("모니터링을 중지하는데 실패했습니다:", error);
-    }
-  }, []);
+  const [frontmostMonitoredApp, setFrontmostMonitoredApp] = useState<string | null>(null);
+  const [hasResolvedFrontmostMonitoredApp, setHasResolvedFrontmostMonitoredApp] = useState(false);
 
   // 실시간 업데이트 리스너 및 자동 시작
   useEffect(() => {
@@ -48,11 +24,23 @@ export const useAppMonitor = () => {
       }
     });
 
-    const unsubscribeSessionUpdated = window.api.onSessionUpdated(session => {
-      if (!cancelled) {
-        setSessions(prev => [...prev, session]);
+    const refreshFrontmostMonitoredApp = async () => {
+      try {
+        const appName = await window.api.getFrontmostMonitoredApp();
+        if (!cancelled) {
+          setFrontmostMonitoredApp(appName);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setFrontmostMonitoredApp(null);
+          console.error("전면 개발 앱 조회 실패:", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setHasResolvedFrontmostMonitoredApp(true);
+        }
       }
-    });
+    };
 
     // 비동기 시작 함수
     const initMonitoring = async () => {
@@ -62,8 +50,6 @@ export const useAppMonitor = () => {
           return;
         }
 
-        setIsMonitoring(true);
-
         // 초기 상태 로드
         const currentApp = await window.api.getActiveApp();
         if (cancelled) {
@@ -71,13 +57,6 @@ export const useAppMonitor = () => {
         }
 
         setActiveApp(currentApp);
-
-        const currentSessions = await window.api.getSessions();
-        if (cancelled) {
-          return;
-        }
-
-        setSessions(currentSessions);
       } catch (error) {
         console.error("모니터링을 시작하는데 실패했습니다:", error);
       } finally {
@@ -87,22 +66,26 @@ export const useAppMonitor = () => {
       }
     };
 
-    initMonitoring();
+    void initMonitoring();
+    void refreshFrontmostMonitoredApp();
+    const frontmostAppInterval = setInterval(() => {
+      void refreshFrontmostMonitoredApp();
+    }, FRONTMOST_APP_POLL_MS);
 
     // Cleanup
     return () => {
       cancelled = true;
+      clearInterval(frontmostAppInterval);
       unsubscribeAppChanged();
-      unsubscribeSessionUpdated();
     };
   }, []);
 
   return {
     activeApp,
-    sessions,
-    isMonitoring,
     hasInitialized,
-    startMonitoring,
-    stopMonitoring,
+    frontmostMonitoredApp,
+    hasResolvedFrontmostMonitoredApp,
   };
 };
+
+export type UseAppMonitorResult = ReturnType<typeof useAppMonitor>;

--- a/apps/mac/src/renderer/src/features/app-monitor/model/usePresenceStatus.ts
+++ b/apps/mac/src/renderer/src/features/app-monitor/model/usePresenceStatus.ts
@@ -4,10 +4,9 @@ import type { CursorScreenPoint, PresenceStatus } from "./realtimeSync.types";
 
 const AWAY_THRESHOLD_MS = 5 * 60 * 1000;
 const PRESENCE_CHECK_INTERVAL_MS = 5000;
-const FRONTMOST_APP_POLL_MS = 2000;
 const CURSOR_POLL_MS = 60 * 1000;
 
-export const usePresenceStatus = () => {
+export const usePresenceStatus = (isDeveloping: boolean) => {
   const { data: todayResponse } = useRecordTodayQuery();
   const hasActiveRecordSession =
     !!todayResponse?.success &&
@@ -17,8 +16,8 @@ export const usePresenceStatus = () => {
   const lastCursorMovedAtRef = useRef(0);
   const cursorPointRef = useRef<CursorScreenPoint | null>(null);
   const hasActiveRecordSessionRef = useRef(hasActiveRecordSession);
-  const isDevelopingRef = useRef(false);
-  const wasExemptFromAwayRef = useRef(hasActiveRecordSession);
+  const isDevelopingRef = useRef(isDeveloping);
+  const wasExemptFromAwayRef = useRef(hasActiveRecordSession || isDeveloping);
 
   const updatePresenceStatus = useCallback((nextStatus: PresenceStatus) => {
     setPresenceStatus(previousStatus =>
@@ -53,6 +52,7 @@ export const usePresenceStatus = () => {
 
   useEffect(() => {
     hasActiveRecordSessionRef.current = hasActiveRecordSession;
+    isDevelopingRef.current = isDeveloping;
 
     const timer = setTimeout(() => {
       syncPresence();
@@ -61,62 +61,7 @@ export const usePresenceStatus = () => {
     return () => {
       clearTimeout(timer);
     };
-  }, [hasActiveRecordSession, syncPresence]);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.api) {
-      return;
-    }
-
-    window.api.startMonitoring().catch(error => {
-      console.error("앱 모니터링을 시작하는데 실패했습니다:", error);
-    });
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.api) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const refreshFrontmostMonitoredApp = async () => {
-      try {
-        const appName = await window.api.getFrontmostMonitoredApp();
-        if (cancelled) {
-          return;
-        }
-
-        const isDeveloping = appName !== null;
-        if (isDevelopingRef.current === isDeveloping) {
-          return;
-        }
-
-        isDevelopingRef.current = isDeveloping;
-        syncPresence();
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
-        if (isDevelopingRef.current) {
-          isDevelopingRef.current = false;
-          syncPresence();
-        }
-        console.error("전면 개발 앱 조회 실패:", error);
-      }
-    };
-
-    void refreshFrontmostMonitoredApp();
-    const interval = setInterval(() => {
-      void refreshFrontmostMonitoredApp();
-    }, FRONTMOST_APP_POLL_MS);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [syncPresence]);
+  }, [hasActiveRecordSession, isDeveloping, syncPresence]);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.api) {
@@ -135,11 +80,7 @@ export const usePresenceStatus = () => {
         const previousPoint = cursorPointRef.current;
         cursorPointRef.current = point;
 
-        if (
-          previousPoint === null ||
-          previousPoint.x !== point.x ||
-          previousPoint.y !== point.y
-        ) {
+        if (previousPoint === null || previousPoint.x !== point.x || previousPoint.y !== point.y) {
           lastCursorMovedAtRef.current = Date.now();
           updatePresenceStatus("ONLINE");
         }

--- a/apps/mac/src/renderer/src/features/app-monitor/model/useRealtimeSync.ts
+++ b/apps/mac/src/renderer/src/features/app-monitor/model/useRealtimeSync.ts
@@ -62,8 +62,8 @@ const shouldRetrySocketToken = (error: unknown) => {
   return status >= 500;
 };
 
-export const useRealtimeSync = () => {
-  const presenceStatus = usePresenceStatus();
+export const useRealtimeSync = (isDeveloping: boolean) => {
+  const presenceStatus = usePresenceStatus(isDeveloping);
   const socketRef = useRef<Socket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);

--- a/apps/mac/src/renderer/src/features/attendance/model/useAttendanceDialog.ts
+++ b/apps/mac/src/renderer/src/features/attendance/model/useAttendanceDialog.ts
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   isAttended,
   useMarkAttendanceMutation,
   useWeeklyAttendanceQuery,
   type WeeklyAttendanceResponse,
 } from "@/entities/attendance";
+import { userQueryKeys } from "@/entities/user";
 import { getErrorMessage } from "@/shared/lib";
 
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
@@ -32,6 +34,7 @@ const getIsTodayAttended = (
 };
 
 export const useAttendanceDialog = () => {
+  const queryClient = useQueryClient();
   const currentAttendanceDate = getCurrentAttendanceDate();
   const { data: weeklyAttendance = null } = useWeeklyAttendanceQuery();
   const { mutateAsync: markAttendance, isPending: isSubmitting } = useMarkAttendanceMutation();
@@ -68,9 +71,9 @@ export const useAttendanceDialog = () => {
 
   const isOpen = Boolean(
     weeklyAttendance &&
-      (isCompletingAttendance ||
-        isManuallyOpen ||
-        (!isTodayAttended && dismissedAttendanceDate !== currentAttendanceDate))
+    (isCompletingAttendance ||
+      isManuallyOpen ||
+      (!isTodayAttended && dismissedAttendanceDate !== currentAttendanceDate))
   );
 
   const open = () => {
@@ -106,6 +109,7 @@ export const useAttendanceDialog = () => {
 
     try {
       await markAttendance();
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
       clearCloseTimeout();
       setOptimisticAttendedDate(currentAttendanceDate);
       setAnimatedAttendanceDate(currentAttendanceDate);

--- a/apps/mac/src/renderer/src/features/auth/sign-in/model/useDevelopSignIn.ts
+++ b/apps/mac/src/renderer/src/features/auth/sign-in/model/useDevelopSignIn.ts
@@ -2,7 +2,7 @@ import type { ChangeEvent, FormEvent } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { authApi, startUserProfileSyncWindow } from "@/entities/user";
+import { authApi, startUserProfileSyncWindow, userQueryKeys } from "@/entities/user";
 import { getErrorMessage } from "@/shared/lib";
 import { useElectronAuthFlow } from "./useElectronAuthFlow";
 
@@ -52,7 +52,7 @@ export const useDevelopSignIn = () => {
       }
 
       startUserProfileSyncWindow();
-      await queryClient.invalidateQueries({ queryKey: ["user"] });
+      await queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
       navigate("/");
     } catch (error: unknown) {
       console.error("Embedded sign in failed:", error);

--- a/apps/mac/src/renderer/src/features/auth/sign-in/model/useElectronAuthFlow.ts
+++ b/apps/mac/src/renderer/src/features/auth/sign-in/model/useElectronAuthFlow.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
-import { authApi, startUserProfileSyncWindow } from "@/entities/user";
+import { authApi, startUserProfileSyncWindow, userQueryKeys } from "@/entities/user";
 import { appRuntimeProfile } from "@/shared/config/appRuntime";
 import { getErrorMessage } from "@/shared/lib";
 
@@ -56,7 +56,7 @@ export const useElectronAuthFlow = () => {
       }
 
       startUserProfileSyncWindow();
-      await queryClient.invalidateQueries({ queryKey: ["user"] });
+      await queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
       setPendingAuth(null);
       navigate("/");
       return true;

--- a/apps/mac/src/renderer/src/features/auth/sign-out/model/useSignOut.ts
+++ b/apps/mac/src/renderer/src/features/auth/sign-out/model/useSignOut.ts
@@ -1,12 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import { authApi } from "@/entities/user";
-import { getErrorMessage } from "@/shared/lib";
+import { getErrorMessage, resetSession } from "@/shared/lib";
 
 export const useSignOut = () => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,17 +19,7 @@ export const useSignOut = () => {
       console.error("로그아웃 실패:", error);
       setError(getErrorMessage(error, "로그아웃에 실패했습니다."));
     } finally {
-      // 재실행 시 세션 복원을 막기 위해 Electron 쿠키를 강제로 비움
-      if (typeof window !== "undefined" && window.api?.clearAuthSession) {
-        try {
-          await window.api.clearAuthSession();
-        } catch (error) {
-          console.error("세션 쿠키 정리에 실패했습니다:", error);
-        }
-      }
-
-      // 모든 캐시 제거
-      queryClient.clear();
+      await resetSession();
 
       // 로그인 페이지로 이동
       navigate("/sign-in", { replace: true });

--- a/apps/mac/src/renderer/src/features/chapter/model/useChapter.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useChapter.ts
@@ -209,6 +209,7 @@ export const useChapter = (sectionId: number) => {
     !hasCurrentStageDetails && (chapterDetailsQuery.isLoading || resetOnOpenState.isLoading);
 
   const handlers = useChapterHandlers({
+    sectionId,
     stages: domain.stages,
     setStageOverrides: domain.setStageOverrides,
     currentStageId,

--- a/apps/mac/src/renderer/src/features/chapter/model/useChapterHandlers.ts
+++ b/apps/mac/src/renderer/src/features/chapter/model/useChapterHandlers.ts
@@ -1,11 +1,18 @@
 import { useRef, type Dispatch, type SetStateAction } from "react";
 import type { Stage, Mission, StageStatus } from "@/features/chapter/model/chapter.types";
 import { useQueryClient } from "@tanstack/react-query";
-import { chapterQueryKeys, type GetChapterDetailsResponse } from "@/entities/roadmap";
+import {
+  chapterQueryKeys,
+  chapterRankingQueryKeys,
+  previewQueryKeys,
+  sectionQueryKeys,
+  type GetChapterDetailsResponse,
+} from "@/entities/roadmap";
 
 type StageOverride = Partial<Pick<Stage, "status" | "currentProgress">>;
 
 type UseChapterHandlersParams = {
+  sectionId: number;
   stages: Stage[];
   setStageOverrides: Dispatch<SetStateAction<Record<number, StageOverride>>>;
   currentStageId: number;
@@ -18,6 +25,7 @@ type UseChapterHandlersParams = {
 };
 
 export const useChapterHandlers = ({
+  sectionId,
   stages,
   setStageOverrides,
   currentStageId,
@@ -84,6 +92,13 @@ export const useChapterHandlers = ({
         };
       }
     );
+
+    void Promise.all([
+      queryClient.invalidateQueries({ queryKey: chapterQueryKeys.sectionDetails(sectionId) }),
+      queryClient.invalidateQueries({ queryKey: previewQueryKeys.detail(sectionId) }),
+      queryClient.invalidateQueries({ queryKey: sectionQueryKeys.all }),
+      queryClient.invalidateQueries({ queryKey: chapterRankingQueryKeys.all }),
+    ]);
 
     const currentStageIndex = stages.findIndex(stage => stage.id === currentStageId);
     const currentStage = currentStageIndex >= 0 ? stages[currentStageIndex] : null;

--- a/apps/mac/src/renderer/src/features/competition/model/useBattle.ts
+++ b/apps/mac/src/renderer/src/features/competition/model/useBattle.ts
@@ -182,7 +182,7 @@ export const useBattle = () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: battleQueryKeys.applications }),
         queryClient.invalidateQueries({ queryKey: battleQueryKeys.list }),
-        queryClient.invalidateQueries({ queryKey: battleQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: battleQueryKeys.info }),
       ]);
     },
   });

--- a/apps/mac/src/renderer/src/features/github/model/useGitHub.ts
+++ b/apps/mac/src/renderer/src/features/github/model/useGitHub.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { githubApi, startUserProfileSyncWindow } from "@/entities/user";
+import { activeQueryKeys, compareQueryKeys, transitionQueryKeys } from "@/entities/competition";
+import { githubApi, startUserProfileSyncWindow, userQueryKeys } from "@/entities/user";
 import { appRuntimeProfile } from "@/shared/config/appRuntime";
+import { SESSION_STORAGE_KEYS } from "@/shared/config/sessionStorage";
 import { getErrorMessage } from "@/shared/lib";
 
 interface DeepLinkAuthPayload {
@@ -10,7 +12,7 @@ interface DeepLinkAuthPayload {
   url: string;
 }
 
-const PENDING_GITHUB_STATE_KEY = "clash:github:pending-state";
+const PENDING_GITHUB_STATE_KEY = SESSION_STORAGE_KEYS.githubPendingState;
 const GITHUB_OAUTH_BASE_URL = "https://github.com";
 const GITHUB_OAUTH_REDIRECT_URI = appRuntimeProfile.githubRedirectUri;
 const GITHUB_OAUTH_SCOPE = "read:user user:email repo read:org";
@@ -103,10 +105,10 @@ export const useGitHub = () => {
           setError(null);
 
           await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ["user"] }),
-            queryClient.invalidateQueries({ queryKey: ["compare"] }),
-            queryClient.invalidateQueries({ queryKey: ["transition"] }),
-            queryClient.invalidateQueries({ queryKey: ["active"] }),
+            queryClient.invalidateQueries({ queryKey: userQueryKeys.all }),
+            queryClient.invalidateQueries({ queryKey: compareQueryKeys.all }),
+            queryClient.invalidateQueries({ queryKey: transitionQueryKeys.all }),
+            queryClient.invalidateQueries({ queryKey: activeQueryKeys.all }),
           ]);
         } else {
           setError(result.message || "GitHub 계정 연동에 실패했습니다.");

--- a/apps/mac/src/renderer/src/features/group/model/useGroup.ts
+++ b/apps/mac/src/renderer/src/features/group/model/useGroup.ts
@@ -290,6 +290,7 @@ export const useGroup = (currentGroupId: number | null) => {
           queryClient.invalidateQueries({ queryKey: groupQueryKeys.myGroups }),
           queryClient.invalidateQueries({ queryKey: groupQueryKeys.allGroups }),
           queryClient.invalidateQueries({ queryKey: groupQueryKeys.groupActivity }),
+          queryClient.invalidateQueries({ queryKey: groupQueryKeys.groupDetail }),
         ]);
         return true;
       } else {

--- a/apps/mac/src/renderer/src/features/major-choice/model/useMajorChoice.ts
+++ b/apps/mac/src/renderer/src/features/major-choice/model/useMajorChoice.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Major, majorApi, useMajorQuestionsQuery } from "@/entities/major";
 import { useQueryClient } from "@tanstack/react-query";
-import { useGetMyProfile } from "@/entities/user";
+import { userQueryKeys, useGetMyProfile } from "@/entities/user";
 
 export type FeatureItem = "TEST" | "CHOICE" | null;
 export type StepType = "FEATURE" | "TEST" | "LOADING" | "RESULT" | "CHOICE";
@@ -102,7 +102,7 @@ export const useMajorChoice = () => {
       });
 
       await queryClient.invalidateQueries({
-        queryKey: ["user"],
+        queryKey: userQueryKeys.all,
       });
 
       navigate("/roadmap");

--- a/apps/mac/src/renderer/src/features/notice/model/useTopbarNotice.ts
+++ b/apps/mac/src/renderer/src/features/notice/model/useTopbarNotice.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { battleApi, battleQueryKeys, compareRivalsQueryKeys } from "@/entities/competition";
 import { rivalQueryKeys, rivalsApi } from "@/entities/rival";
+import { userQueryKeys } from "@/entities/user";
 import {
   noticeApi,
   type NoticeItem,
@@ -118,13 +119,15 @@ const invalidateNoticeQueries = async () => {
 const invalidateNoticeRelatedQueries = async () => {
   await Promise.all([
     invalidateNoticeQueries(),
-    queryClient.invalidateQueries({ queryKey: ["user"] }),
+    queryClient.invalidateQueries({ queryKey: userQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: rivalQueryKeys.myRivals }),
+    queryClient.invalidateQueries({ queryKey: rivalQueryKeys.requests }),
     queryClient.invalidateQueries({ queryKey: compareRivalsQueryKeys.all }),
     queryClient.invalidateQueries({ queryKey: battleQueryKeys.info }),
     queryClient.invalidateQueries({ queryKey: battleQueryKeys.details }),
     queryClient.invalidateQueries({ queryKey: battleQueryKeys.analyses }),
     queryClient.invalidateQueries({ queryKey: battleQueryKeys.list }),
+    queryClient.invalidateQueries({ queryKey: battleQueryKeys.applications }),
     queryClient.invalidateQueries({ queryKey: rivalQueryKeys.available }),
   ]);
 };

--- a/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/item-panel/ItemPanel.tsx
+++ b/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/item-panel/ItemPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import * as S from "./ItemPanel.style";
 import { ItemDetailModal } from "./item-detail-modal/ItemDetailModal";
 import {
@@ -9,7 +10,7 @@ import {
   type OwnedItemDisplayCategory,
 } from "@/entities/profile";
 import { sortEquippedItemsFirst } from "@/features/profile/lib/sortEquippedItemsFirst";
-import { useGetMyProfile } from "@/entities/user";
+import { useGetMyProfile, userQueryKeys } from "@/entities/user";
 import { getErrorMessage } from "@/shared/lib";
 
 const FILTER_OPTIONS = [
@@ -26,6 +27,7 @@ const CATEGORY_LABEL: Record<OwnedItemDisplayCategory, string> = {
 };
 
 export const ItemPanel = () => {
+  const queryClient = useQueryClient();
   const [filter, setFilter] = useState<OwnedItemCategory>(OwnedItemCategory.ALL);
   const [selectedItem, setSelectedItem] = useState<OwnedItem | null>(null);
   const { data, isLoading, isFetching, error } = useOwnedItemsQuery(filter);
@@ -77,6 +79,7 @@ export const ItemPanel = () => {
         productId: selectedItem.id,
         shouldUnequip: selectedCategory ? isEquippedItem(selectedCategory, selectedItem.id) : false,
       });
+      await queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
       handleCloseModal();
     } catch {
       return;

--- a/apps/mac/src/renderer/src/features/record/index.ts
+++ b/apps/mac/src/renderer/src/features/record/index.ts
@@ -4,6 +4,7 @@ export { Todo } from "./ui/todo/Todo";
 export { shiftRecordDate } from "./model/recordDate";
 export { useActivityRecordSync } from "./model/useActivityRecordSync";
 export { useLiveRecordStudyTime } from "./model/useLiveRecordStudyTime";
-export { useRecordStore } from "./model/recordStore";
+export { useRecordSessionSync } from "./model/useRecord";
+export { resetRecordStore, useRecordStore } from "./model/recordStore";
 export { useRecordTicker } from "./model/useRecordTicker";
 export { useTodayRecordDate } from "./model/useTodayRecordDate";

--- a/apps/mac/src/renderer/src/features/record/model/recordStore.ts
+++ b/apps/mac/src/renderer/src/features/record/model/recordStore.ts
@@ -1,28 +1,24 @@
 import { create } from "zustand";
+import { recordApi, recordQueryKeys, type RecordSessionType } from "@/entities/record";
 import {
-  recordApi,
-  recordQueryKeys,
-  type RecordSessionType,
-  type Subject,
-  type SubjectTask,
-  type Task,
-} from "@/entities/record";
-import { getErrorMessage, queryClient } from "@/shared/lib";
+  captureSessionEpoch,
+  getErrorMessage,
+  isSessionEpochCurrent,
+  queryClient,
+} from "@/shared/lib";
 
-interface ActiveSessionState {
+interface RecordSessionState {
   activeSessionType: RecordSessionType | null;
   activeSubjectId: number | null;
   activeTaskId: number | null;
   startTime: number | null;
   baseStudyTime: number;
+  currentStudyTime: number;
 }
 
-interface RecordStore extends ActiveSessionState {
-  subjects: Subject[];
-  tasks: Task[];
-  currentStudyTime: number;
+interface RecordStore extends RecordSessionState {
   startSubject: (subjectId: number) => Promise<void>;
-  startTask: (taskId: number) => Promise<void>;
+  startTask: (taskId: number, subjectId: number | null) => Promise<void>;
   stop: () => Promise<boolean>;
   addSubject: (name: string) => Promise<boolean>;
   updateSubject: (subjectId: number, name: string) => Promise<boolean>;
@@ -32,99 +28,59 @@ interface RecordStore extends ActiveSessionState {
   deleteTask: (taskId: number) => Promise<boolean>;
   updateTaskCompletion: (taskId: number, completed: boolean) => Promise<boolean>;
   setCurrentStudyTime: (time: number) => void;
-  setSubjects: (subjects: Subject[]) => void;
-  setTasks: (tasks: Task[]) => void;
-  setActiveSession: (session: ActiveSessionState) => void;
+  setSessionSnapshot: (session: RecordSessionState) => void;
 }
 
-const invalidateRecordQueries = async () => {
+interface StopOperation {
+  epoch: number;
+  promise: Promise<boolean>;
+}
+
+const invalidateSubjectQueries = async (epoch: number) => {
+  if (!isSessionEpochCurrent(epoch)) {
+    return false;
+  }
+
+  await queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects });
+  return isSessionEpochCurrent(epoch);
+};
+
+const invalidateTaskQueries = async (epoch: number) => {
+  if (!isSessionEpochCurrent(epoch)) {
+    return false;
+  }
+
+  await queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks });
+  return isSessionEpochCurrent(epoch);
+};
+
+const invalidateTodayQuery = async (epoch: number) => {
+  if (!isSessionEpochCurrent(epoch)) {
+    return false;
+  }
+
+  await queryClient.invalidateQueries({ queryKey: recordQueryKeys.today });
+  return isSessionEpochCurrent(epoch);
+};
+
+const invalidateRecordQueries = async (epoch: number) => {
+  if (!isSessionEpochCurrent(epoch)) {
+    return false;
+  }
+
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
     queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
     queryClient.invalidateQueries({ queryKey: recordQueryKeys.today }),
   ]);
+  return isSessionEpochCurrent(epoch);
 };
 
-const updateNestedSubjectTasks = (
-  tasks: SubjectTask[],
-  taskId: number,
-  updater: (task: SubjectTask) => SubjectTask
-) => tasks.map(task => (task.id === taskId ? updater(task) : task));
+let stopInFlight: StopOperation | null = null;
 
-const applyElapsedStudyTime = (
-  subjects: Subject[],
-  tasks: Task[],
-  activeSubjectId: number | null,
-  activeTaskId: number | null,
-  elapsedSeconds: number
-) => {
-  const nextTasks =
-    activeTaskId === null
-      ? tasks
-      : tasks.map(task =>
-          task.id === activeTaskId ? { ...task, studyTime: task.studyTime + elapsedSeconds } : task
-        );
-
-  const nextSubjects =
-    activeSubjectId === null
-      ? subjects
-      : subjects.map(subject => {
-          const nextStudyTime =
-            subject.id === activeSubjectId ? subject.studyTime + elapsedSeconds : subject.studyTime;
-
-          if (activeTaskId === null) {
-            return subject.id === activeSubjectId
-              ? { ...subject, studyTime: nextStudyTime }
-              : subject;
-          }
-
-          return {
-            ...subject,
-            studyTime: nextStudyTime,
-            tasks:
-              subject.id === activeSubjectId
-                ? updateNestedSubjectTasks(subject.tasks, activeTaskId, task => ({
-                    ...task,
-                    studyTime: task.studyTime + elapsedSeconds,
-                  }))
-                : subject.tasks,
-          };
-        });
-
-  return { subjects: nextSubjects, tasks: nextTasks };
-};
-
-const updateSubjectList = (
-  subjects: Subject[],
-  subjectId: number,
-  updater: (subject: Subject) => Subject
-) => subjects.map(subject => (subject.id === subjectId ? updater(subject) : subject));
-
-const applyTaskCompletionState = (
-  subjects: Subject[],
-  tasks: Task[],
-  taskId: number,
-  subjectId: number | null,
-  completed: boolean
-) => ({
-  tasks: tasks.map(task => (task.id === taskId ? { ...task, completed } : task)),
-  subjects:
-    subjectId === null
-      ? subjects
-      : updateSubjectList(subjects, subjectId, subject => ({
-          ...subject,
-          tasks: updateNestedSubjectTasks(subject.tasks, taskId, nestedTask => ({
-            ...nestedTask,
-            completed,
-          })),
-        })),
-});
-
-let stopInFlight: Promise<boolean> | null = null;
+const hasStopInFlight = (epoch: number) => stopInFlight?.epoch === epoch;
 
 export const useRecordStore = create<RecordStore>((set, get) => ({
-  subjects: [],
-  tasks: [],
   activeSessionType: null,
   activeSubjectId: null,
   activeTaskId: null,
@@ -133,16 +89,26 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   baseStudyTime: 0,
 
   startSubject: async subjectId => {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return;
+    }
+
     const { activeSessionType, activeSubjectId, activeTaskId } = get();
 
     try {
-      if (activeSessionType === "TASK" && activeSubjectId === subjectId && activeTaskId === null) {
+      if (
+        !hasStopInFlight(epoch) &&
+        activeSessionType === "TASK" &&
+        activeSubjectId === subjectId &&
+        activeTaskId === null
+      ) {
         return;
       }
 
-      if (activeSessionType !== null) {
+      if (activeSessionType !== null || hasStopInFlight(epoch)) {
         const stopped = await get().stop();
-        if (!stopped) {
+        if (!isSessionEpochCurrent(epoch) || !stopped) {
           return;
         }
       }
@@ -154,87 +120,87 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
         appId: null,
       });
 
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return;
       }
 
-      set(state => ({
+      set({
         activeSessionType: "TASK",
         activeSubjectId: subjectId,
         activeTaskId: null,
         startTime: Date.now(),
         currentStudyTime: 0,
-        baseStudyTime: state.baseStudyTime,
-      }));
-      await queryClient.invalidateQueries({ queryKey: recordQueryKeys.today });
+      });
+      await invalidateTodayQuery(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       const errorMessage = getErrorMessage(error, "과목 기록 시작에 실패했습니다.");
       console.error("과목 기록 시작 실패:", errorMessage, error);
     }
   },
 
-  startTask: async taskId => {
-    const { tasks, activeSessionType, activeTaskId } = get();
-    const task = tasks.find(item => item.id === taskId);
-
-    if (!task) {
+  startTask: async (taskId, subjectId) => {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
       return;
     }
 
+    const { activeSessionType, activeTaskId } = get();
+
     try {
-      if (activeSessionType === "TASK" && activeTaskId === taskId) {
+      if (!hasStopInFlight(epoch) && activeSessionType === "TASK" && activeTaskId === taskId) {
         return;
       }
 
-      if (activeSessionType !== null) {
+      if (activeSessionType !== null || hasStopInFlight(epoch)) {
         const stopped = await get().stop();
-        if (!stopped) {
+        if (!isSessionEpochCurrent(epoch) || !stopped) {
           return;
         }
       }
 
       const response = await recordApi.startRecord({
         sessionType: "TASK",
-        subjectId: task.subjectId,
+        subjectId,
         taskId,
         appId: null,
       });
 
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return;
       }
 
-      set(state => ({
+      set({
         activeSessionType: "TASK",
-        activeSubjectId: task.subjectId,
+        activeSubjectId: subjectId,
         activeTaskId: taskId,
         startTime: Date.now(),
         currentStudyTime: 0,
-        baseStudyTime: state.baseStudyTime,
-      }));
-      await queryClient.invalidateQueries({ queryKey: recordQueryKeys.today });
+      });
+      await invalidateTodayQuery(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       const errorMessage = getErrorMessage(error, "할 일 기록 시작에 실패했습니다.");
       console.error("할 일 기록 시작 실패:", errorMessage, error);
     }
   },
 
   stop: async () => {
-    if (stopInFlight) {
-      return stopInFlight;
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
     }
 
-    const runStop = async (): Promise<boolean> => {
-      const {
-        subjects,
-        tasks,
-        activeSessionType,
-        activeSubjectId,
-        activeTaskId,
-        startTime,
-        currentStudyTime,
-        baseStudyTime,
-      } = get();
+    let operation = stopInFlight?.epoch === epoch ? stopInFlight : null;
+
+    if (!operation) {
+      const { activeSessionType, startTime, currentStudyTime, baseStudyTime } = get();
 
       if (activeSessionType === null) {
         return true;
@@ -245,57 +211,79 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
           ? Math.max(0, Math.floor((Date.now() - startTime) / 1000))
           : Math.max(0, currentStudyTime);
 
-      const nextStudyState =
-        elapsedAtStop > 0
-          ? applyElapsedStudyTime(subjects, tasks, activeSubjectId, activeTaskId, elapsedAtStop)
-          : { subjects, tasks };
+      const promise = (async () => {
+        try {
+          const response = await recordApi.stopRecord();
 
-      set({
-        subjects: nextStudyState.subjects,
-        tasks: nextStudyState.tasks,
-        activeSessionType: null,
-        activeSubjectId: null,
-        activeTaskId: null,
-        startTime: null,
-        currentStudyTime: 0,
-        baseStudyTime: baseStudyTime + elapsedAtStop,
-      });
+          if (!isSessionEpochCurrent(epoch)) {
+            return false;
+          }
 
-      try {
-        const response = await recordApi.stopRecord();
+          if (!response.success) {
+            console.error("기록 중지 실패:", "기록 중지 응답이 실패로 반환되었습니다.", response);
+            return false;
+          }
 
-        if (!response.success) {
-          console.error("기록 중지 실패:", "기록 중지 응답이 실패로 반환되었습니다.", response);
-          await invalidateRecordQueries();
+          set({
+            activeSessionType: null,
+            activeSubjectId: null,
+            activeTaskId: null,
+            startTime: null,
+            currentStudyTime: 0,
+            baseStudyTime: baseStudyTime + elapsedAtStop,
+          });
+          return true;
+        } catch (error: unknown) {
+          if (!isSessionEpochCurrent(epoch)) {
+            return false;
+          }
+
+          const errorMessage = getErrorMessage(error, "기록 중지에 실패했습니다.");
+          console.error("기록 중지 실패:", errorMessage, error);
           return false;
         }
+      })();
 
-        await invalidateRecordQueries();
-        return true;
-      } catch (error: unknown) {
-        const errorMessage = getErrorMessage(error, "기록 중지에 실패했습니다.");
-        console.error("기록 중지 실패:", errorMessage, error);
-        await invalidateRecordQueries();
-        return false;
+      operation = { epoch, promise };
+      stopInFlight = operation;
+    }
+
+    let stopped = false;
+
+    try {
+      stopped = await operation.promise;
+    } finally {
+      if (stopInFlight === operation) {
+        stopInFlight = null;
       }
-    };
+    }
 
-    stopInFlight = runStop();
-    const stopped = await stopInFlight;
-    stopInFlight = null;
-    return stopped;
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
+    const refreshed = await invalidateRecordQueries(epoch);
+    return stopped && refreshed;
   },
 
   addSubject: async name => {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
     try {
       const response = await recordApi.createSubject({ name });
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return false;
       }
 
-      await queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects });
-      return true;
+      return await invalidateSubjectQueries(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "과목 추가에 실패했습니다.");
       console.error("과목 추가 실패:", errorMessage, error);
       return false;
@@ -303,19 +291,27 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   updateSubject: async (subjectId, name) => {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
     try {
       const response = await recordApi.updateSubject(subjectId, { name });
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return false;
       }
 
-      set(state => ({
-        subjects: state.subjects.map(subject =>
-          subject.id === subjectId ? { ...subject, name } : subject
-        ),
-      }));
-      return true;
+      const results = await Promise.all([
+        invalidateSubjectQueries(epoch),
+        invalidateTodayQuery(epoch),
+      ]);
+      return results.every(Boolean) && isSessionEpochCurrent(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "과목 수정에 실패했습니다.");
       console.error("과목 수정 실패:", errorMessage, error);
       return false;
@@ -323,30 +319,31 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   deleteSubject: async subjectId => {
-    const { activeSubjectId } = get();
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
 
     try {
-      if (activeSubjectId === subjectId || stopInFlight) {
+      if (get().activeSubjectId === subjectId || hasStopInFlight(epoch)) {
         const stopped = await get().stop();
-        if (!stopped) {
-          console.error("과목 삭제 실패:", "기록 중지에 실패해 삭제를 진행하지 않았습니다.");
+        if (!isSessionEpochCurrent(epoch) || !stopped) {
           return false;
         }
       }
 
       const response = await recordApi.deleteSubject(subjectId);
-      if (!response.success) {
-        await invalidateRecordQueries();
+      if (!isSessionEpochCurrent(epoch)) {
         return false;
       }
 
-      set(state => ({
-        subjects: state.subjects.filter(subject => subject.id !== subjectId),
-        tasks: state.tasks.filter(task => task.subjectId !== subjectId),
-      }));
-      await invalidateRecordQueries();
-      return true;
+      const refreshed = await invalidateRecordQueries(epoch);
+      return response.success && refreshed;
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "과목 삭제에 실패했습니다.");
       console.error("과목 삭제 실패:", errorMessage, error);
       return false;
@@ -354,18 +351,27 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   addTask: async (name, subjectId, date) => {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
     try {
       const response = await recordApi.createTask({ name, subjectId, date });
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return false;
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
+      const results = await Promise.all([
+        invalidateSubjectQueries(epoch),
+        invalidateTaskQueries(epoch),
       ]);
-      return true;
+      return results.every(Boolean) && isSessionEpochCurrent(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "할 일 추가에 실패했습니다.");
       console.error("할 일 추가 실패:", errorMessage, error);
       return false;
@@ -373,64 +379,35 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   updateTask: async (taskId, name, subjectId) => {
-    const task = get().tasks.find(item => item.id === taskId);
-
-    if (!task) {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
       return false;
     }
 
     try {
       const response = await recordApi.updateTask(taskId, { name, subjectId });
-      if (!response.success) {
+      if (!isSessionEpochCurrent(epoch) || !response.success) {
         return false;
       }
 
       set(state => ({
-        tasks: state.tasks.map(item => (item.id === taskId ? { ...item, name, subjectId } : item)),
         activeSubjectId:
           state.activeSessionType === "TASK" && state.activeTaskId === taskId
             ? subjectId
             : state.activeSubjectId,
-        subjects: state.subjects.map(subject => {
-          if (subject.id === subjectId && task.subjectId === subjectId) {
-            return {
-              ...subject,
-              tasks: updateNestedSubjectTasks(subject.tasks, taskId, nestedTask => ({
-                ...nestedTask,
-                name,
-              })),
-            };
-          }
-
-          const withoutTask = subject.tasks.filter(nestedTask => nestedTask.id !== taskId);
-
-          if (subject.id === subjectId) {
-            return {
-              ...subject,
-              tasks: [
-                ...withoutTask,
-                {
-                  id: taskId,
-                  name,
-                  icon: task.icon,
-                  completed: task.completed,
-                  studyTime: task.studyTime,
-                },
-              ],
-            };
-          }
-
-          return withoutTask.length === subject.tasks.length
-            ? subject
-            : { ...subject, tasks: withoutTask };
-        }),
       }));
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
+
+      const results = await Promise.all([
+        invalidateSubjectQueries(epoch),
+        invalidateTaskQueries(epoch),
+        invalidateTodayQuery(epoch),
       ]);
-      return true;
+      return results.every(Boolean) && isSessionEpochCurrent(epoch);
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "할 일 수정에 실패했습니다.");
       console.error("할 일 수정 실패:", errorMessage, error);
       return false;
@@ -438,37 +415,31 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   deleteTask: async taskId => {
-    const task = get().tasks.find(item => item.id === taskId);
-
-    if (!task) {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
       return false;
     }
 
     try {
-      if (get().activeTaskId === taskId || stopInFlight) {
+      if (get().activeTaskId === taskId || hasStopInFlight(epoch)) {
         const stopped = await get().stop();
-        if (!stopped) {
-          console.error("할 일 삭제 실패:", "기록 중지에 실패해 삭제를 진행하지 않았습니다.");
+        if (!isSessionEpochCurrent(epoch) || !stopped) {
           return false;
         }
       }
 
       const response = await recordApi.deleteTask(taskId);
-      if (!response.success) {
-        await invalidateRecordQueries();
+      if (!isSessionEpochCurrent(epoch)) {
         return false;
       }
 
-      set(state => ({
-        tasks: state.tasks.filter(item => item.id !== taskId),
-        subjects: state.subjects.map(subject => ({
-          ...subject,
-          tasks: subject.tasks.filter(nestedTask => nestedTask.id !== taskId),
-        })),
-      }));
-      await invalidateRecordQueries();
-      return true;
+      const refreshed = await invalidateRecordQueries(epoch);
+      return response.success && refreshed;
     } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "할 일 삭제에 실패했습니다.");
       console.error("할 일 삭제 실패:", errorMessage, error);
       return false;
@@ -476,78 +447,46 @@ export const useRecordStore = create<RecordStore>((set, get) => ({
   },
 
   updateTaskCompletion: async (taskId, completed) => {
-    const task = get().tasks.find(item => item.id === taskId);
-    let previousState: Pick<RecordStore, "subjects" | "tasks"> | null = null;
-
-    if (!task) {
+    const epoch = captureSessionEpoch();
+    if (!isSessionEpochCurrent(epoch)) {
       return false;
     }
 
     try {
-      if (completed && get().activeTaskId === taskId) {
+      if ((completed && get().activeTaskId === taskId) || hasStopInFlight(epoch)) {
         const stopped = await get().stop();
-        if (!stopped) {
-          console.error(
-            "할 일 완료 처리 실패:",
-            "기록 중지에 실패해 완료 처리를 진행하지 않았습니다."
-          );
+        if (!isSessionEpochCurrent(epoch) || !stopped) {
           return false;
         }
       }
 
-      previousState = {
-        subjects: get().subjects,
-        tasks: get().tasks,
-      };
-
-      set(state =>
-        applyTaskCompletionState(state.subjects, state.tasks, taskId, task.subjectId, completed)
-      );
-
       const response = await recordApi.updateTaskCompletion(taskId, { completed });
-      if (!response.success) {
-        set(previousState);
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
-          queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
-        ]);
+      if (!isSessionEpochCurrent(epoch)) {
         return false;
       }
 
-      const resolvedCompleted = response.data?.completed ?? completed;
-      if (resolvedCompleted !== completed) {
-        set(state =>
-          applyTaskCompletionState(
-            state.subjects,
-            state.tasks,
-            taskId,
-            task.subjectId,
-            resolvedCompleted
-          )
-        );
+      const results = await Promise.all([
+        invalidateSubjectQueries(epoch),
+        invalidateTaskQueries(epoch),
+      ]);
+      return response.success && results.every(Boolean) && isSessionEpochCurrent(epoch);
+    } catch (error: unknown) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
-      ]);
-      return true;
-    } catch (error: unknown) {
-      if (previousState) {
-        set(previousState);
-      }
       const errorMessage = getErrorMessage(error, "할 일 완료 상태 변경에 실패했습니다.");
       console.error("할 일 완료 상태 변경 실패:", errorMessage, error);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.subjects }),
-        queryClient.invalidateQueries({ queryKey: recordQueryKeys.tasks }),
-      ]);
+      await Promise.all([invalidateSubjectQueries(epoch), invalidateTaskQueries(epoch)]);
       return false;
     }
   },
 
   setCurrentStudyTime: time => set({ currentStudyTime: time }),
-  setSubjects: subjects => set({ subjects }),
-  setTasks: tasks => set({ tasks }),
-  setActiveSession: session => set(session),
+  setSessionSnapshot: session => set(session),
 }));
+
+export const resetRecordStore = () => {
+  stopInFlight = null;
+  useRecordStore.setState(useRecordStore.getInitialState(), true);
+};

--- a/apps/mac/src/renderer/src/features/record/model/useActivityRecordSync.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useActivityRecordSync.ts
@@ -6,7 +6,12 @@ import {
   recordApi,
   recordQueryKeys,
 } from "@/entities/record";
-import { getErrorMessage, queryClient } from "@/shared/lib";
+import {
+  captureSessionEpoch,
+  getErrorMessage,
+  isSessionEpochCurrent,
+  queryClient,
+} from "@/shared/lib";
 
 type ServerSessionState =
   | { type: "NONE"; appId: null }
@@ -38,14 +43,19 @@ export const useActivityRecordSync = (
   isFrontmostMonitoredApp: boolean,
   isReady: boolean
 ) => {
+  const sessionEpochRef = useRef(captureSessionEpoch());
   const pendingTargetsRef = useRef<Array<string | null>>([]);
   const monitoredAppsRef = useRef<MonitoredApp[] | null>(null);
   const serverSessionRef = useRef<ServerSessionState>({ type: "NONE", appId: null });
   const requiresFrontmostToRestartRef = useRef(false);
-  const initializedRef = useRef(false);
+  const initializedEpochRef = useRef<number | null>(null);
   const syncingRef = useRef(false);
 
   const enqueueTarget = useCallback((targetAppName: string | null) => {
+    if (!isSessionEpochCurrent(sessionEpochRef.current)) {
+      return;
+    }
+
     const queue = pendingTargetsRef.current;
     if (queue.length > 0 && queue[queue.length - 1] === targetAppName) {
       return;
@@ -54,44 +64,84 @@ export const useActivityRecordSync = (
     queue.push(targetAppName);
   }, []);
 
-  const invalidateToday = useCallback(async () => {
+  const invalidateToday = useCallback(async (epoch: number) => {
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
     await queryClient.invalidateQueries({ queryKey: recordQueryKeys.today });
+    return isSessionEpochCurrent(epoch);
   }, []);
 
-  const loadMonitoredApps = useCallback(async () => {
+  const loadMonitoredApps = useCallback(async (epoch: number) => {
+    if (!isSessionEpochCurrent(epoch)) {
+      return false;
+    }
+
     try {
       const response = await recordApi.getMonitoredApps();
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       if (response.success && response.data?.apps) {
         monitoredAppsRef.current = response.data.apps;
-        return;
+        return true;
       }
     } catch (error) {
+      if (!isSessionEpochCurrent(epoch)) {
+        return false;
+      }
+
       const errorMessage = getErrorMessage(error, "활동 기록 가능 앱 목록 조회에 실패했습니다.");
       console.error("활동 기록 가능 앱 목록 조회 실패:", errorMessage, error);
     }
 
     monitoredAppsRef.current = [];
+    return true;
   }, []);
 
-  const loadCurrentSession = useCallback(async (): Promise<ServerSessionState> => {
-    try {
-      const response = await recordApi.getCurrentRecord();
-      if (!response.success) {
+  const loadCurrentSession = useCallback(
+    async (epoch: number): Promise<ServerSessionState | null> => {
+      if (!isSessionEpochCurrent(epoch)) {
+        return null;
+      }
+
+      try {
+        const response = await recordApi.getCurrentRecord();
+        if (!isSessionEpochCurrent(epoch)) {
+          return null;
+        }
+
+        if (!response.success) {
+          return { type: "NONE", appId: null };
+        }
+        return parseServerSession(response.data);
+      } catch (error) {
+        if (!isSessionEpochCurrent(epoch)) {
+          return null;
+        }
+
+        const errorMessage = getErrorMessage(error, "현재 기록 세션 조회에 실패했습니다.");
+        console.error("현재 기록 세션 조회 실패:", errorMessage, error);
         return { type: "NONE", appId: null };
       }
-      return parseServerSession(response.data);
-    } catch (error) {
-      const errorMessage = getErrorMessage(error, "현재 기록 세션 조회에 실패했습니다.");
-      console.error("현재 기록 세션 조회 실패:", errorMessage, error);
-      return { type: "NONE", appId: null };
-    }
-  }, []);
+    },
+    []
+  );
 
-  const refreshServerSession = useCallback(async (): Promise<ServerSessionState> => {
-    const latestSession = await loadCurrentSession();
-    serverSessionRef.current = latestSession;
-    return latestSession;
-  }, [loadCurrentSession]);
+  const refreshServerSession = useCallback(
+    async (epoch: number): Promise<ServerSessionState | null> => {
+      const latestSession = await loadCurrentSession(epoch);
+      if (!latestSession || !isSessionEpochCurrent(epoch)) {
+        return null;
+      }
+
+      serverSessionRef.current = latestSession;
+      return latestSession;
+    },
+    [loadCurrentSession]
+  );
 
   const normalizeTargetAppId = useCallback((rawAppName: string | null) => {
     if (!rawAppName) {
@@ -106,28 +156,60 @@ export const useActivityRecordSync = (
     return matchMonitoredApp(rawAppName, monitoredApps);
   }, []);
 
-  const stopDevelopSession = useCallback(async () => {
-    try {
-      const stopResponse = await recordApi.stopRecord();
-      if (!stopResponse.success) {
-        console.error("개발 기록 중지 API 실패 응답:", stopResponse.message);
-        await refreshServerSession();
+  const stopDevelopSession = useCallback(
+    async (epoch: number) => {
+      if (!isSessionEpochCurrent(epoch)) {
         return;
       }
 
-      serverSessionRef.current = { type: "NONE", appId: null };
-      await invalidateToday();
-    } catch (error) {
-      const errorMessage = getErrorMessage(error, "개발 기록 중지에 실패했습니다.");
-      console.error("개발 기록 중지 실패:", errorMessage, error);
-      await refreshServerSession();
-    }
-  }, [invalidateToday, refreshServerSession]);
+      try {
+        const stopResponse = await recordApi.stopRecord();
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
+        if (!stopResponse.success) {
+          console.error("개발 기록 중지 API 실패 응답:", stopResponse.message);
+          await refreshServerSession(epoch);
+          if (!isSessionEpochCurrent(epoch)) {
+            return;
+          }
+          return;
+        }
+
+        serverSessionRef.current = { type: "NONE", appId: null };
+        await invalidateToday(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+      } catch (error) {
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
+        const errorMessage = getErrorMessage(error, "개발 기록 중지에 실패했습니다.");
+        console.error("개발 기록 중지 실패:", errorMessage, error);
+        await refreshServerSession(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+      }
+    },
+    [invalidateToday, refreshServerSession]
+  );
 
   const switchDevelopSession = useCallback(
-    async (targetAppId: MonitoredApp) => {
+    async (targetAppId: MonitoredApp, epoch: number) => {
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       try {
         const switchResponse = await recordApi.switchDevelopApp({ appId: targetAppId });
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
         const switchedSession = switchResponse.data?.session;
         if (
           !switchResponse.success ||
@@ -137,7 +219,10 @@ export const useActivityRecordSync = (
           if (!switchResponse.success) {
             console.error("개발 기록 전환 API 실패 응답:", switchResponse.message);
           }
-          await refreshServerSession();
+          await refreshServerSession(epoch);
+          if (!isSessionEpochCurrent(epoch)) {
+            return;
+          }
           return;
         }
 
@@ -145,18 +230,32 @@ export const useActivityRecordSync = (
           type: "DEVELOP",
           appId: switchedSession.develop.appId,
         };
-        await invalidateToday();
+        await invalidateToday(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
       } catch (error) {
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
         const errorMessage = getErrorMessage(error, "개발 기록 전환에 실패했습니다.");
         console.error("개발 기록 전환 실패:", errorMessage, error);
-        await refreshServerSession();
+        await refreshServerSession(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
       }
     },
     [invalidateToday, refreshServerSession]
   );
 
   const startDevelopSession = useCallback(
-    async (targetAppId: MonitoredApp) => {
+    async (targetAppId: MonitoredApp, epoch: number) => {
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       try {
         const startResponse = await recordApi.startRecord({
           sessionType: "DEVELOP",
@@ -164,12 +263,19 @@ export const useActivityRecordSync = (
           taskId: null,
           appId: targetAppId,
         });
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
         const startedSession = startResponse.data?.session;
         if (!startResponse.success || !startedSession || startedSession.sessionType !== "DEVELOP") {
           if (!startResponse.success) {
             console.error("개발 기록 시작 API 실패 응답:", startResponse.message);
           }
-          await refreshServerSession();
+          await refreshServerSession(epoch);
+          if (!isSessionEpochCurrent(epoch)) {
+            return;
+          }
           return;
         }
 
@@ -177,20 +283,37 @@ export const useActivityRecordSync = (
           type: "DEVELOP",
           appId: startedSession.develop.appId,
         };
-        await invalidateToday();
+        await invalidateToday(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
       } catch (error) {
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
+
         const errorMessage = getErrorMessage(error, "개발 기록 시작에 실패했습니다.");
         console.error("개발 기록 시작 실패:", errorMessage, error);
-        await refreshServerSession();
+        await refreshServerSession(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
       }
     },
     [invalidateToday, refreshServerSession]
   );
 
   const syncServerSession = useCallback(
-    async (rawTargetAppName: string | null) => {
+    async (rawTargetAppName: string | null, epoch: number) => {
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       const targetAppId = normalizeTargetAppId(rawTargetAppName);
-      const serverSession = await refreshServerSession();
+      const serverSession = await refreshServerSession(epoch);
+      if (!serverSession || !isSessionEpochCurrent(epoch)) {
+        return;
+      }
 
       if (serverSession.type === "TASK") {
         requiresFrontmostToRestartRef.current = true;
@@ -208,7 +331,10 @@ export const useActivityRecordSync = (
           return;
         }
 
-        await stopDevelopSession();
+        await stopDevelopSession(epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
         return;
       }
 
@@ -216,7 +342,10 @@ export const useActivityRecordSync = (
         if (serverSession.appId === targetAppId) {
           return;
         }
-        await switchDevelopSession(targetAppId);
+        await switchDevelopSession(targetAppId, epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          return;
+        }
         return;
       }
 
@@ -224,7 +353,11 @@ export const useActivityRecordSync = (
         return;
       }
 
-      await startDevelopSession(targetAppId);
+      await startDevelopSession(targetAppId, epoch);
+      if (!isSessionEpochCurrent(epoch)) {
+        return;
+      }
+
       requiresFrontmostToRestartRef.current = false;
     },
     [
@@ -238,6 +371,12 @@ export const useActivityRecordSync = (
   );
 
   const flushSync = useCallback(async () => {
+    const renderSessionEpoch = sessionEpochRef.current;
+    const epoch = captureSessionEpoch();
+    if (epoch !== renderSessionEpoch || !isSessionEpochCurrent(epoch)) {
+      return;
+    }
+
     if (syncingRef.current) {
       return;
     }
@@ -245,15 +384,39 @@ export const useActivityRecordSync = (
     syncingRef.current = true;
     try {
       while (pendingTargetsRef.current.length > 0) {
-        const targetAppName = pendingTargetsRef.current.shift() ?? null;
-
-        if (!initializedRef.current) {
-          await loadMonitoredApps();
-          serverSessionRef.current = await loadCurrentSession();
-          initializedRef.current = true;
+        if (!isSessionEpochCurrent(epoch)) {
+          pendingTargetsRef.current = [];
+          return;
         }
 
-        await syncServerSession(targetAppName);
+        const targetAppName = pendingTargetsRef.current.shift() ?? null;
+
+        if (initializedEpochRef.current !== epoch) {
+          monitoredAppsRef.current = null;
+          serverSessionRef.current = { type: "NONE", appId: null };
+          requiresFrontmostToRestartRef.current = false;
+
+          const monitoredAppsLoaded = await loadMonitoredApps(epoch);
+          if (!monitoredAppsLoaded || !isSessionEpochCurrent(epoch)) {
+            pendingTargetsRef.current = [];
+            return;
+          }
+
+          const currentSession = await loadCurrentSession(epoch);
+          if (!currentSession || !isSessionEpochCurrent(epoch)) {
+            pendingTargetsRef.current = [];
+            return;
+          }
+
+          serverSessionRef.current = currentSession;
+          initializedEpochRef.current = epoch;
+        }
+
+        await syncServerSession(targetAppName, epoch);
+        if (!isSessionEpochCurrent(epoch)) {
+          pendingTargetsRef.current = [];
+          return;
+        }
       }
     } finally {
       syncingRef.current = false;

--- a/apps/mac/src/renderer/src/features/record/model/useLiveRecordStudyTime.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useLiveRecordStudyTime.ts
@@ -1,13 +1,28 @@
 import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useRecordTodayQuery } from "@/entities/record";
 import { useRecordStore } from "./recordStore";
 
+const HISTORICAL_RECORD_TIME = {
+  activeSessionType: null,
+  baseStudyTime: 0,
+  currentStudyTime: 0,
+} as const;
+
 export const useLiveRecordStudyTime = (selectedDate?: string) => {
-  const { data: todayResponse, isPending } = useRecordTodayQuery(selectedDate);
-  const activeSessionType = useRecordStore(state => state.activeSessionType);
-  const baseStudyTime = useRecordStore(state => state.baseStudyTime);
-  const currentStudyTime = useRecordStore(state => state.currentStudyTime);
   const isTodaySelected = selectedDate === undefined;
+  const { data: todayResponse, isPending } = useRecordTodayQuery(selectedDate);
+  const { activeSessionType, baseStudyTime, currentStudyTime } = useRecordStore(
+    useShallow(state =>
+      isTodaySelected
+        ? {
+            activeSessionType: state.activeSessionType,
+            baseStudyTime: state.baseStudyTime,
+            currentStudyTime: state.currentStudyTime,
+          }
+        : HISTORICAL_RECORD_TIME
+    )
+  );
   const isLoading = !isTodaySelected && isPending && todayResponse === undefined;
 
   const hasServerActiveSession = useMemo(() => {
@@ -19,15 +34,19 @@ export const useLiveRecordStudyTime = (selectedDate?: string) => {
   }, [todayResponse]);
 
   const totalStudyTime = useMemo(() => {
-    if (isTodaySelected && activeSessionType !== null) {
-      return baseStudyTime + currentStudyTime;
+    if (isTodaySelected) {
+      if (activeSessionType !== null || baseStudyTime > 0) {
+        return baseStudyTime + currentStudyTime;
+      }
+
+      return todayResponse?.success && todayResponse.data ? todayResponse.data.totalStudyTime : 0;
     }
 
     if (todayResponse?.success && todayResponse.data) {
       return todayResponse.data.totalStudyTime;
     }
 
-    return isTodaySelected ? baseStudyTime + currentStudyTime : 0;
+    return 0;
   }, [activeSessionType, baseStudyTime, currentStudyTime, isTodaySelected, todayResponse]);
 
   return {

--- a/apps/mac/src/renderer/src/features/record/model/useRecord.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useRecord.ts
@@ -1,40 +1,17 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRecordStore } from "./recordStore";
-import {
-  useRecordSubjectsQuery,
-  useRecordTasksQuery,
-  useRecordTodayQuery,
-} from "@/entities/record";
+import { useRecordTodayQuery } from "@/entities/record";
+import { captureSessionEpoch, isSessionEpochCurrent } from "@/shared/lib";
 
-export const useRecord = (selectedDate?: string) => {
-  const { setCurrentStudyTime, setSubjects, setTasks, setActiveSession } = useRecordStore();
-  const { data: subjectsResponse } = useRecordSubjectsQuery(selectedDate);
-  const { data: tasksResponse } = useRecordTasksQuery(selectedDate);
-  const { data: todayResponse } = useRecordTodayQuery(selectedDate);
+export const useRecordSessionSync = () => {
+  const setSessionSnapshot = useRecordStore(state => state.setSessionSnapshot);
+  const todayQuery = useRecordTodayQuery();
+  const { data: todayResponse } = todayQuery;
+  const sessionEpochRef = useRef(captureSessionEpoch());
 
   useEffect(() => {
-    if (!subjectsResponse?.success || !subjectsResponse.data) {
-      return;
-    }
-
-    if (!tasksResponse?.success || !tasksResponse.data) {
-      return;
-    }
-
-    setSubjects(subjectsResponse.data.subjects);
-    setTasks(tasksResponse.data.tasks);
-  }, [setSubjects, setTasks, subjectsResponse, tasksResponse]);
-
-  useEffect(() => {
-    if (!todayResponse?.success || !todayResponse.data) {
-      setActiveSession({
-        activeSessionType: null,
-        activeSubjectId: null,
-        activeTaskId: null,
-        startTime: null,
-        baseStudyTime: 0,
-      });
-      setCurrentStudyTime(0);
+    const sessionEpoch = sessionEpochRef.current;
+    if (!isSessionEpochCurrent(sessionEpoch) || !todayResponse?.success || !todayResponse.data) {
       return;
     }
 
@@ -42,29 +19,33 @@ export const useRecord = (selectedDate?: string) => {
       todayResponse.data.sessions.find(session => session.endedAt === null) ?? null;
 
     if (!activeSession) {
-      setActiveSession({
+      setSessionSnapshot({
         activeSessionType: null,
         activeSubjectId: null,
         activeTaskId: null,
         startTime: null,
         baseStudyTime: todayResponse.data.totalStudyTime,
+        currentStudyTime: 0,
       });
-      setCurrentStudyTime(0);
       return;
     }
 
     const serverStartTime = new Date(activeSession.startedAt).getTime();
     const now = Date.now();
-    const elapsedSeconds = Math.max(0, Math.floor((now - serverStartTime) / 1000));
+    const elapsedSeconds = Number.isFinite(serverStartTime)
+      ? Math.max(0, Math.floor((now - serverStartTime) / 1000))
+      : 0;
     const baseStudyTime = Math.max(todayResponse.data.totalStudyTime - elapsedSeconds, 0);
 
-    setActiveSession({
+    setSessionSnapshot({
       activeSessionType: activeSession.sessionType,
       activeSubjectId: activeSession.subject?.id ?? null,
       activeTaskId: activeSession.task?.id ?? null,
       startTime: now - elapsedSeconds * 1000,
       baseStudyTime,
+      currentStudyTime: elapsedSeconds,
     });
-    setCurrentStudyTime(elapsedSeconds);
-  }, [setActiveSession, setCurrentStudyTime, todayResponse]);
+  }, [setSessionSnapshot, todayResponse]);
+
+  return todayQuery;
 };

--- a/apps/mac/src/renderer/src/features/record/model/useRecordTicker.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useRecordTicker.ts
@@ -1,15 +1,24 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRecordStore } from "./recordStore";
+import { captureSessionEpoch, isSessionEpochCurrent } from "@/shared/lib";
 
 export const useRecordTicker = () => {
-  const { activeSessionType, startTime, setCurrentStudyTime } = useRecordStore();
+  const activeSessionType = useRecordStore(state => state.activeSessionType);
+  const startTime = useRecordStore(state => state.startTime);
+  const setCurrentStudyTime = useRecordStore(state => state.setCurrentStudyTime);
+  const sessionEpochRef = useRef(captureSessionEpoch());
 
   useEffect(() => {
-    if (activeSessionType === null || startTime === null) {
+    const sessionEpoch = sessionEpochRef.current;
+    if (activeSessionType === null || startTime === null || !isSessionEpochCurrent(sessionEpoch)) {
       return;
     }
 
     const updateCurrentStudyTime = () => {
+      if (!isSessionEpochCurrent(sessionEpoch)) {
+        return;
+      }
+
       setCurrentStudyTime(Math.max(0, Math.floor((Date.now() - startTime) / 1000)));
     };
 

--- a/apps/mac/src/renderer/src/features/record/model/useTaskList.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useTaskList.ts
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useRecordStore } from "./recordStore";
-import { useRecordTodayQuery } from "@/entities/record";
+import { useRecordSubjectsQuery, useRecordTodayQuery, type Subject } from "@/entities/record";
 
 type EditMode = "NONE" | "ADD" | "EDIT";
 const MAX_TASK_NAME_LENGTH = 13;
 const TASK_NAME_INPUT_MAX_LENGTH = 14;
+const EMPTY_SUBJECTS: Subject[] = [];
 
 const getTaskNameErrorMessage = (name: string) => {
   const trimmedLength = name.trim().length;
@@ -21,8 +23,10 @@ const getTaskNameErrorMessage = (name: string) => {
 };
 
 export const useTaskList = (selectedDate?: string) => {
+  const isTodaySelected = selectedDate === undefined;
+  const { data: subjectsResponse } = useRecordSubjectsQuery(selectedDate);
+  const subjects = subjectsResponse?.data?.subjects ?? EMPTY_SUBJECTS;
   const {
-    subjects,
     activeSessionType,
     activeSubjectId,
     currentStudyTime,
@@ -31,8 +35,21 @@ export const useTaskList = (selectedDate?: string) => {
     addSubject,
     updateSubject,
     deleteSubject,
-  } = useRecordStore();
-  const isTodaySelected = selectedDate === undefined;
+  } = useRecordStore(
+    useShallow(state => ({
+      activeSessionType: state.activeSessionType,
+      activeSubjectId: state.activeSubjectId,
+      currentStudyTime:
+        isTodaySelected && state.activeSessionType === "TASK" && state.activeSubjectId !== null
+          ? state.currentStudyTime
+          : 0,
+      startSubject: state.startSubject,
+      stop: state.stop,
+      addSubject: state.addSubject,
+      updateSubject: state.updateSubject,
+      deleteSubject: state.deleteSubject,
+    }))
+  );
   const { data: todayResponse } = useRecordTodayQuery(selectedDate);
 
   const [editMode, setEditMode] = useState<EditMode>("NONE");
@@ -257,7 +274,7 @@ export const useTaskList = (selectedDate?: string) => {
   };
 
   const isSubjectActive = (subjectId: number) =>
-    activeSessionType === "TASK" && activeSubjectId === subjectId;
+    isTodaySelected && activeSessionType === "TASK" && activeSubjectId === subjectId;
 
   const getSubjectStudyTime = (subjectId: number) => {
     const subject = subjects.find(item => item.id === subjectId);

--- a/apps/mac/src/renderer/src/features/record/model/useTodoList.ts
+++ b/apps/mac/src/renderer/src/features/record/model/useTodoList.ts
@@ -1,4 +1,11 @@
 import { useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
+import { useShallow } from "zustand/react/shallow";
+import {
+  useRecordSubjectsQuery,
+  useRecordTasksQuery,
+  type Subject,
+  type Task,
+} from "@/entities/record";
 import { useRecordStore } from "./recordStore";
 
 type EditMode = "NONE" | "ADD" | "EDIT";
@@ -6,6 +13,8 @@ const NO_PARENT_SUBJECT = "NONE";
 
 const MAX_TODO_NAME_LENGTH = 13;
 const TODO_NAME_INPUT_MAX_LENGTH = 14;
+const EMPTY_SUBJECTS: Subject[] = [];
+const EMPTY_TASKS: Task[] = [];
 
 const getTodoNameErrorMessage = (name: string) => {
   const trimmedLength = name.trim().length;
@@ -22,9 +31,12 @@ const getTodoNameErrorMessage = (name: string) => {
 };
 
 export const useTodoList = (selectedDate?: string) => {
+  const isTodaySelected = selectedDate === undefined;
+  const { data: subjectsResponse } = useRecordSubjectsQuery(selectedDate);
+  const { data: tasksResponse } = useRecordTasksQuery(selectedDate);
+  const subjects = subjectsResponse?.data?.subjects ?? EMPTY_SUBJECTS;
+  const tasks = tasksResponse?.data?.tasks ?? EMPTY_TASKS;
   const {
-    subjects,
-    tasks,
     activeSessionType,
     activeTaskId,
     startTask,
@@ -33,8 +45,18 @@ export const useTodoList = (selectedDate?: string) => {
     updateTask,
     deleteTask,
     updateTaskCompletion,
-  } = useRecordStore();
-  const isTodaySelected = selectedDate === undefined;
+  } = useRecordStore(
+    useShallow(state => ({
+      activeSessionType: state.activeSessionType,
+      activeTaskId: state.activeTaskId,
+      startTask: state.startTask,
+      stop: state.stop,
+      addTask: state.addTask,
+      updateTask: state.updateTask,
+      deleteTask: state.deleteTask,
+      updateTaskCompletion: state.updateTaskCompletion,
+    }))
+  );
   const [editMode, setEditMode] = useState<EditMode>("NONE");
   const [editingTodoId, setEditingTodoId] = useState<number | null>(null);
   const [todoName, setTodoName] = useState("");
@@ -203,7 +225,7 @@ export const useTodoList = (selectedDate?: string) => {
       }
     }
 
-    await startTask(todoId);
+    await startTask(todoId, todo.subjectId);
   };
 
   const handleCompleteClick = async (todoId: number, nextCompleted: boolean) => {
@@ -236,7 +258,7 @@ export const useTodoList = (selectedDate?: string) => {
 
   return {
     todos: tasks.map(task => {
-      const isActive = activeSessionType === "TASK" && activeTaskId === task.id;
+      const isActive = isTodaySelected && activeSessionType === "TASK" && activeTaskId === task.id;
 
       return {
         id: task.id,

--- a/apps/mac/src/renderer/src/features/record/ui/Record.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/Record.tsx
@@ -1,7 +1,6 @@
 import * as S from "./Record.style";
 import { Task } from "./task/Task";
 import { Timer } from "./timer/Timer";
-import { useRecord } from "../model/useRecord";
 
 interface RecordProps {
   selectedDate?: string;
@@ -20,8 +19,6 @@ export const Record = ({
   onResetToToday,
   canGoNextDate,
 }: RecordProps) => {
-  useRecord(selectedDate);
-
   return (
     <S.RecordContainer>
       <S.TopContainer>

--- a/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
@@ -24,7 +24,8 @@ export const Timer = ({
   stopButtonPosition = "LEFT",
   nonTodayStopBehavior = "disable",
 }: TimerProps) => {
-  const { activeSessionType, stop } = useRecordStore();
+  const activeSessionType = useRecordStore(state => state.activeSessionType);
+  const stop = useRecordStore(state => state.stop);
   const { totalStudyTime, isLoading } = useLiveRecordStudyTime(selectedDate);
   const isTodaySelected = selectedDate === undefined;
   const isPreviousDateEnabled = typeof onPreviousDate === "function";

--- a/apps/mac/src/renderer/src/features/shop/model/usePurchaseProduct.ts
+++ b/apps/mac/src/renderer/src/features/shop/model/usePurchaseProduct.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { productQueryKeys } from "@/entities/product";
+import { ownedItemsQueryKeys } from "@/entities/profile";
 import { purchaseProduct, type PurchaseRequest } from "@/entities/shop";
+import { userQueryKeys } from "@/entities/user";
 
 export const usePurchaseProduct = () => {
   const queryClient = useQueryClient();
@@ -10,7 +12,8 @@ export const usePurchaseProduct = () => {
 
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["user"] }),
+        queryClient.invalidateQueries({ queryKey: userQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: ownedItemsQueryKeys.all }),
         queryClient.invalidateQueries({ queryKey: productQueryKeys.all }),
       ]);
     },

--- a/apps/mac/src/renderer/src/main.tsx
+++ b/apps/mac/src/renderer/src/main.tsx
@@ -1,4 +1,7 @@
-import { createRoot } from 'react-dom/client'
-import App from './app/App'
+import { createRoot } from "react-dom/client";
+import App from "./app/App";
+import { registerSessionResetHandlers } from "@/app/session/registerSessionResetHandlers";
 
-createRoot(document.getElementById('root')!).render(<App />)
+registerSessionResetHandlers();
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/mac/src/renderer/src/pages/home/ui/Home.tsx
+++ b/apps/mac/src/renderer/src/pages/home/ui/Home.tsx
@@ -12,7 +12,12 @@ import {
   useActiveQuery,
   useTransitionQuery,
 } from "@/entities/competition";
-import { PROFILE_SYNC_INTERVAL_MS, PROFILE_SYNC_UNTIL_KEY, useGetMyProfile } from "@/entities/user";
+import {
+  PROFILE_SYNC_INTERVAL_MS,
+  PROFILE_SYNC_UNTIL_KEY,
+  userQueryKeys,
+  useGetMyProfile,
+} from "@/entities/user";
 
 const isNotFound = (error: unknown) => axios.isAxiosError(error) && error.response?.status === 404;
 
@@ -70,7 +75,7 @@ export const Home = () => {
     }
 
     const interval = setInterval(() => {
-      void queryClient.invalidateQueries({ queryKey: ["user"] });
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
     }, PROFILE_SYNC_INTERVAL_MS);
 
     return () => {

--- a/apps/mac/src/renderer/src/shared/api/axios.ts
+++ b/apps/mac/src/renderer/src/shared/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { appRuntimeProfile } from "@/shared/config/appRuntime";
+import { resetUnauthorizedSession } from "@/shared/lib/sessionReset";
 
 const BASE_URL = import.meta.env.VITE_API_URL;
 
@@ -40,7 +41,7 @@ api.interceptors.response.use(
         case 401:
           // Auth 관련 API는 리다이렉트 X
           if (!isPublicPath) {
-            window.location.href = "#/sign-in";
+            void resetUnauthorizedSession();
           }
           break;
         case 403:

--- a/apps/mac/src/renderer/src/shared/config/sessionStorage.ts
+++ b/apps/mac/src/renderer/src/shared/config/sessionStorage.ts
@@ -1,0 +1,6 @@
+export const SESSION_STORAGE_KEYS = {
+  githubPendingState: "clash:github:pending-state",
+  profileSyncUntil: "clash:home-ranking-user:profile-sync-until",
+} as const;
+
+export const AUTH_SESSION_STORAGE_KEYS = Object.values(SESSION_STORAGE_KEYS);

--- a/apps/mac/src/renderer/src/shared/lib/index.ts
+++ b/apps/mac/src/renderer/src/shared/lib/index.ts
@@ -9,6 +9,12 @@ export {
   useServiceUnavailable,
 } from "./useServiceUnavailable";
 export { queryClient } from "./queryClient";
+export {
+  captureSessionEpoch,
+  isSessionEpochCurrent,
+  registerSessionResetHandler,
+  resetSession,
+} from "./sessionReset";
 export { getErrorMessage } from "./error";
 export { buildPaddedStreak } from "./buildPaddedStreaks";
 export { getGrowthInfo } from "./getGrowthInfo";

--- a/apps/mac/src/renderer/src/shared/lib/sessionReset.ts
+++ b/apps/mac/src/renderer/src/shared/lib/sessionReset.ts
@@ -1,0 +1,115 @@
+import { AUTH_SESSION_STORAGE_KEYS } from "../config/sessionStorage";
+import { queryClient } from "./queryClient";
+
+type SessionResetHandler = () => void | Promise<void>;
+
+const resetHandlers = new Map<string, SessionResetHandler>();
+let resetInFlight: Promise<void> | null = null;
+let unauthorizedResetInFlight: Promise<void> | null = null;
+let sessionEpoch = 0;
+let isResettingSession = false;
+
+export const captureSessionEpoch = () => sessionEpoch;
+
+export const isSessionEpochCurrent = (epoch: number) =>
+  !isResettingSession && epoch === sessionEpoch;
+
+export const registerSessionResetHandler = (key: string, handler: SessionResetHandler) => {
+  resetHandlers.set(key, handler);
+
+  return () => {
+    if (resetHandlers.get(key) === handler) {
+      resetHandlers.delete(key);
+    }
+  };
+};
+
+const clearAuthSessionStorage = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    for (const key of AUTH_SESSION_STORAGE_KEYS) {
+      window.sessionStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.error("인증 세션 저장소 정리에 실패했습니다:", error);
+  }
+};
+
+const clearElectronAuthSession = async () => {
+  if (typeof window === "undefined" || !window.api?.clearAuthSession) {
+    return;
+  }
+
+  try {
+    await window.api.clearAuthSession();
+  } catch (error) {
+    console.error("세션 쿠키 정리에 실패했습니다:", error);
+  }
+};
+
+export const resetSession = () => {
+  if (resetInFlight) {
+    return resetInFlight;
+  }
+
+  sessionEpoch += 1;
+  isResettingSession = true;
+
+  resetInFlight = Promise.resolve()
+    .then(async () => {
+      try {
+        await queryClient.cancelQueries();
+      } catch (error) {
+        console.error("세션 query 취소에 실패했습니다:", error);
+      }
+
+      try {
+        queryClient.clear();
+      } catch (error) {
+        console.error("세션 query cache 정리에 실패했습니다:", error);
+      }
+      clearAuthSessionStorage();
+
+      const resetResults = await Promise.allSettled(
+        [...resetHandlers.values()].map(async handler => {
+          await handler();
+        })
+      );
+
+      for (const result of resetResults) {
+        if (result.status === "rejected") {
+          console.error("세션 상태 초기화에 실패했습니다:", result.reason);
+        }
+      }
+
+      await clearElectronAuthSession();
+    })
+    .finally(() => {
+      sessionEpoch += 1;
+      isResettingSession = false;
+      resetInFlight = null;
+    });
+
+  return resetInFlight;
+};
+
+export const resetUnauthorizedSession = () => {
+  if (unauthorizedResetInFlight) {
+    return unauthorizedResetInFlight;
+  }
+
+  unauthorizedResetInFlight = resetSession()
+    .then(() => {
+      if (typeof window !== "undefined" && !window.location.hash.startsWith("#/sign-in")) {
+        window.location.replace("#/sign-in");
+      }
+    })
+    .finally(() => {
+      unauthorizedResetInFlight = null;
+    });
+
+  return unauthorizedResetInFlight;
+};

--- a/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.tsx
+++ b/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.tsx
@@ -2,11 +2,13 @@ import * as S from "./Sidebar.style";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import type { MonitoredApp } from "@/entities/record";
+import type { UseAppMonitorResult } from "@/features/app-monitor";
 import { IdeIcons } from "@/shared/ui/assets/ide-img";
 import { useSidebarMonitor } from "./model/useSidebarMonitor";
 
 interface SidebarProps {
   isOpen: boolean;
+  appMonitor: UseAppMonitorResult;
 }
 
 const menuItems = [
@@ -31,10 +33,10 @@ const isEditableElement = (target: EventTarget | null) => {
   );
 };
 
-export const Sidebar = ({ isOpen }: SidebarProps) => {
+export const Sidebar = ({ isOpen, appMonitor }: SidebarProps) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { isElectron, activeSession, displayTime } = useSidebarMonitor();
+  const { isElectron, activeSession, displayTime } = useSidebarMonitor(appMonitor);
   const hasIdeIcon = (appId: MonitoredApp | null): appId is keyof typeof IdeIcons => {
     return !!appId && appId in IdeIcons;
   };

--- a/apps/mac/src/renderer/src/widgets/sidebar/model/useSidebarMonitor.ts
+++ b/apps/mac/src/renderer/src/widgets/sidebar/model/useSidebarMonitor.ts
@@ -1,22 +1,29 @@
 import { useEffect, useMemo, useState } from "react";
-import { useAppMonitor } from "@/features/app-monitor";
+import type { UseAppMonitorResult } from "@/features/app-monitor";
 import { formatDuration } from "@/entities/app-monitor";
-import { getMonitoredAppLabel, useRecordTodayQuery } from "@/entities/record";
-import { useActivityRecordSync, useRecordStore, useRecordTicker } from "@/features/record";
+import { getMonitoredAppLabel } from "@/entities/record";
+import {
+  useActivityRecordSync,
+  useRecordSessionSync,
+  useRecordStore,
+  useRecordTicker,
+} from "@/features/record";
 import { formatTime } from "@/shared/lib";
 
-export const useSidebarMonitor = () => {
+export const useSidebarMonitor = (appMonitor: UseAppMonitorResult) => {
   // Electron 환경 체크
   const isElectron = !!(typeof window !== "undefined" && window.api);
 
+  const {
+    activeApp,
+    frontmostMonitoredApp,
+    hasInitialized: hasInitializedAppMonitor,
+    hasResolvedFrontmostMonitoredApp,
+  } = appMonitor;
+  const { data: todayResponse } = useRecordSessionSync();
   useRecordTicker();
-
-  const { activeApp, hasInitialized: hasInitializedAppMonitor } = useAppMonitor();
-  const { data: todayResponse } = useRecordTodayQuery();
   const activeSessionType = useRecordStore(state => state.activeSessionType);
   const currentStudyTime = useRecordStore(state => state.currentStudyTime);
-  const [frontmostMonitoredApp, setFrontmostMonitoredApp] = useState<string | null>(null);
-  const [hasResolvedFrontmostMonitoredApp, setHasResolvedFrontmostMonitoredApp] = useState(false);
   const [fallbackDisplayTime, setFallbackDisplayTime] = useState("00:00:00");
 
   const isTaskRecording = useMemo(
@@ -73,36 +80,6 @@ export const useSidebarMonitor = () => {
     isFrontmostMonitoredApp,
     isActivitySyncReady
   );
-
-  useEffect(() => {
-    if (!isElectron) {
-      return;
-    }
-
-    let cancelled = false;
-
-    const refreshFrontmostMonitoredApp = async () => {
-      try {
-        const appName = await window.api.getFrontmostMonitoredApp();
-        if (!cancelled) {
-          setFrontmostMonitoredApp(appName);
-          setHasResolvedFrontmostMonitoredApp(true);
-        }
-      } catch (error) {
-        console.error("전면 개발 앱 조회 실패:", error);
-      }
-    };
-
-    void refreshFrontmostMonitoredApp();
-    const interval = setInterval(() => {
-      void refreshFrontmostMonitoredApp();
-    }, 2000);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [isElectron]);
 
   // 실시간 시간 업데이트
   useEffect(() => {

--- a/apps/web/src/features/auth/sign-up/model/useSignUp.ts
+++ b/apps/web/src/features/auth/sign-up/model/useSignUp.ts
@@ -1,6 +1,6 @@
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useRef, useState, type ChangeEvent } from "react";
 import { z } from "zod";
 import axios from "axios";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
@@ -70,17 +70,32 @@ const getSignUpFieldErrorMessage = (error: unknown, fieldName: keyof SignUpFormD
 
   const fieldMessage = error.response?.data?.error?.details?.[fieldName];
 
-  return typeof fieldMessage === "string" && fieldMessage.trim().length > 0
-    ? fieldMessage
-    : null;
+  return typeof fieldMessage === "string" && fieldMessage.trim().length > 0 ? fieldMessage : null;
 };
 
 // EmailVerify Schema
 const emailVerifySchema = z.object({
-  verificationCode: z.string("유효한 이메일 확인 코드를 입력하세요."),
+  verificationCode: z
+    .array(z.string())
+    .refine(
+      digits => digits.length === 6 && digits.every(digit => /^\d$/.test(digit)),
+      "6자리 이메일 확인 코드를 입력하세요."
+    ),
 });
 
 export type EmailVerifyFormData = z.infer<typeof emailVerifySchema>;
+
+type UsernameCheckStatus = "idle" | "checking" | "available" | "unavailable";
+
+interface UsernameCheckState {
+  status: UsernameCheckStatus;
+  username: string;
+}
+
+const INITIAL_USERNAME_CHECK_STATE: UsernameCheckState = {
+  status: "idle",
+  username: "",
+};
 
 export const useSignUp = () => {
   const navigate = useNavigate();
@@ -89,9 +104,10 @@ export const useSignUp = () => {
   const [step, setStep] = useState<"SIGNUP" | "EMAIL_VERIFY">("SIGNUP");
 
   // SignUp 상태
-  const [checkedUsername, setCheckedUsername] = useState<string>("");
-  const [usernameAvailable, setUsernameAvailable] = useState(false);
-  const [isCheckingUsername, setIsCheckingUsername] = useState(false);
+  const [usernameCheck, setUsernameCheck] = useState<UsernameCheckState>(
+    INITIAL_USERNAME_CHECK_STATE
+  );
+  const usernameCheckRequestId = useRef(0);
   const [email, setEmail] = useState<string>("");
 
   const signUpForm = useForm<SignUpFormData>({
@@ -100,24 +116,42 @@ export const useSignUp = () => {
 
   const emailVerifyForm = useForm<EmailVerifyFormData>({
     resolver: zodResolver(emailVerifySchema),
+    defaultValues: {
+      verificationCode: ["", "", "", "", "", ""],
+    },
   });
 
-  const username = useWatch({
-    control: signUpForm.control,
-    name: "username",
-  });
+  const username =
+    useWatch({
+      control: signUpForm.control,
+      name: "username",
+    }) ?? "";
+  const usernameRegister = signUpForm.register("username");
 
-  // username이 변경되면 자동으로 false
-  const usernameChecked = checkedUsername === username && checkedUsername !== "";
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    usernameCheckRequestId.current += 1;
+    setUsernameCheck(INITIAL_USERNAME_CHECK_STATE);
+    void usernameRegister.onChange(event);
+  };
+
+  const usernameCheckMatches = usernameCheck.username === username && username !== "";
+  const isCheckingUsername = usernameCheckMatches && usernameCheck.status === "checking";
+  const usernameChecked =
+    usernameCheckMatches &&
+    (usernameCheck.status === "available" || usernameCheck.status === "unavailable");
+  const usernameAvailable = usernameCheckMatches && usernameCheck.status === "available";
 
   // 아이디 중복 확인 API
   const handleUsernameCheck = async () => {
     const currentUsername = signUpForm.getValues("username");
+    const requestId = ++usernameCheckRequestId.current;
+    const isCurrentRequest = () =>
+      requestId === usernameCheckRequestId.current &&
+      signUpForm.getValues("username") === currentUsername;
     const validationResult = usernameSchema.safeParse(currentUsername);
 
     if (!validationResult.success) {
-      setCheckedUsername("");
-      setUsernameAvailable(false);
+      setUsernameCheck(INITIAL_USERNAME_CHECK_STATE);
       signUpForm.setError("username", {
         type: "manual",
         message: validationResult.error.issues[0]?.message ?? USERNAME_REQUIRED_MESSAGE,
@@ -125,19 +159,25 @@ export const useSignUp = () => {
       return;
     }
 
+    if (!executeRecaptcha) {
+      setUsernameCheck(INITIAL_USERNAME_CHECK_STATE);
+      signUpForm.setError("username", {
+        type: "manual",
+        message: "보안 인증을 불러오는 중입니다. 잠시 후 다시 시도해주세요.",
+      });
+      return;
+    }
+
     try {
-      setIsCheckingUsername(true);
+      setUsernameCheck({ status: "checking", username: currentUsername });
       signUpForm.clearErrors("username");
 
-      if (!executeRecaptcha) {
-        signUpForm.setError("username", {
-          type: "manual",
-          message: "보안 인증을 불러오는 중입니다. 잠시 후 다시 시도해주세요.",
-        });
+      const recaptchaToken = await executeRecaptcha("username_duplicate_check");
+
+      if (!isCurrentRequest()) {
         return;
       }
 
-      const recaptchaToken = await executeRecaptcha("username_duplicate_check");
       const result = await authApi.usernameDuplicateCheck(
         {
           username: currentUsername,
@@ -145,46 +185,47 @@ export const useSignUp = () => {
         { recaptchaToken }
       );
 
+      if (!isCurrentRequest()) {
+        return;
+      }
+
       if (result.data?.duplicated === false) {
-        setUsernameAvailable(true);
-        setCheckedUsername(currentUsername);
+        setUsernameCheck({ status: "available", username: currentUsername });
         signUpForm.clearErrors("username");
         return;
       }
 
       if (result.data?.duplicated === true) {
-        setUsernameAvailable(false);
-        setCheckedUsername(currentUsername);
+        setUsernameCheck({ status: "unavailable", username: currentUsername });
         signUpForm.clearErrors("username");
         return;
       }
 
-      setCheckedUsername("");
-      setUsernameAvailable(false);
+      setUsernameCheck(INITIAL_USERNAME_CHECK_STATE);
       signUpForm.setError("username", {
         type: "manual",
         message: result.message || USERNAME_CHECK_ERROR_MESSAGE,
       });
     } catch (error: unknown) {
+      if (!isCurrentRequest()) {
+        return;
+      }
+
       console.error("사용자 아이디 중복 검증에 실패했습니다.", error);
 
       const { code, status, message } = getApiError(error, USERNAME_CHECK_ERROR_MESSAGE);
 
       if (isUsernameDuplicateError(code, status)) {
-        setUsernameAvailable(false);
-        setCheckedUsername(currentUsername);
+        setUsernameCheck({ status: "unavailable", username: currentUsername });
         signUpForm.clearErrors("username");
         return;
       }
 
-      setCheckedUsername("");
-      setUsernameAvailable(false);
+      setUsernameCheck(INITIAL_USERNAME_CHECK_STATE);
       signUpForm.setError("username", {
         type: "manual",
         message,
       });
-    } finally {
-      setIsCheckingUsername(false);
     }
   };
 
@@ -274,7 +315,7 @@ export const useSignUp = () => {
 
       const result = await authApi.verifyEmail(
         {
-          verificationCode: data.verificationCode,
+          verificationCode: data.verificationCode.join(""),
         },
         { recaptchaToken }
       );
@@ -301,19 +342,20 @@ export const useSignUp = () => {
     step,
     signUp: {
       register: signUpForm.register,
+      usernameRegister,
       handleSubmit: signUpForm.handleSubmit,
       errors: signUpForm.formState.errors,
       isSubmitting: signUpForm.formState.isSubmitting,
       isCheckingUsername,
       usernameChecked,
       usernameAvailable,
+      handleUsernameChange,
       handleUsernameCheck,
       onSubmit: handleSignUp,
     },
     emailVerify: {
-      register: emailVerifyForm.register,
       handleSubmit: emailVerifyForm.handleSubmit,
-      setValue: emailVerifyForm.setValue,
+      control: emailVerifyForm.control,
       errors: emailVerifyForm.formState.errors,
       isSubmitting: emailVerifyForm.formState.isSubmitting,
       email,

--- a/apps/web/src/features/auth/sign-up/ui/step/EmailVerify.tsx
+++ b/apps/web/src/features/auth/sign-up/ui/step/EmailVerify.tsx
@@ -1,11 +1,5 @@
-import {
-  useRef,
-  useState,
-  useEffect,
-  type ChangeEvent,
-  type KeyboardEvent,
-  type ClipboardEvent,
-} from "react";
+import { useRef, type ChangeEvent, type KeyboardEvent, type ClipboardEvent } from "react";
+import { useController } from "react-hook-form";
 import { useLocation } from "react-router-dom";
 import * as S from "./EmailVerify.style";
 import * as CommonS from "../SignUpForm.style";
@@ -13,7 +7,7 @@ import type { EmailVerifyProps } from "@/features/auth/sign-up/model/useSignUp";
 
 export const EmailVerify = ({
   handleSubmit,
-  setValue,
+  control,
   errors,
   email,
   isSubmitting,
@@ -21,13 +15,13 @@ export const EmailVerify = ({
 }: EmailVerifyProps) => {
   const location = useLocation();
   const search = location.search;
-  const [code, setCode] = useState<string[]>(["", "", "", "", "", ""]);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
-
-  // code가 변경될 때마다 react hook form의 emailCode 값 업데이트
-  useEffect(() => {
-    setValue("verificationCode", code.join(""));
-  }, [code, setValue]);
+  const {
+    field: { onChange: setCode, value: code },
+  } = useController({
+    control,
+    name: "verificationCode",
+  });
 
   const handleChange = (index: number, e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;

--- a/apps/web/src/features/auth/sign-up/ui/step/SignUp.tsx
+++ b/apps/web/src/features/auth/sign-up/ui/step/SignUp.tsx
@@ -4,6 +4,7 @@ import type { SignUpProps } from "@/features/auth/sign-up/model/useSignUp";
 
 export const SignUp = ({
   register,
+  usernameRegister,
   handleSubmit,
   errors,
   onSubmit,
@@ -11,6 +12,7 @@ export const SignUp = ({
   isCheckingUsername,
   usernameChecked,
   usernameAvailable,
+  handleUsernameChange,
   handleUsernameCheck,
 }: SignUpProps) => {
   const location = useLocation();
@@ -21,7 +23,11 @@ export const SignUp = ({
       <S.InputBox>
         <div>
           <S.InputWrapper>
-            <S.Input placeholder="아이디를 입력하세요." {...register("username")} />
+            <S.Input
+              placeholder="아이디를 입력하세요."
+              {...usernameRegister}
+              onChange={handleUsernameChange}
+            />
             <S.VerifyButton
               type="button"
               onClick={handleUsernameCheck}


### PR DESCRIPTION
## 내용
- Record 서버 상태를 React Query로 단일화하고 Zustand에는 live session과 timer만 유지했습니다.
- 전체 도메인의 query key와 cache invalidation 범위를 통일하고 app-monitor polling을 단일 소유로 정리했습니다.
- 401·sign-out 공통 session reset과 epoch fence를 추가해 이전 사용자 상태가 비동기 응답으로 복원되지 않게 했습니다.
- Web username 검증 race와 이메일 인증 코드 이중 state를 제거했습니다.

## 검증
- pnpm lint:fsd
- Mac/Web typecheck 및 lint
- Mac/Web build
- 테스트는 이번 리팩터링 범위에서 제외했습니다.

Closes #620