### PR TITLE
fix: sidebar active color/#638

### DIFF
--- a/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.style.ts
+++ b/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.style.ts
@@ -98,7 +98,7 @@ export const MenuItem = styled(Link)<{ $active?: boolean }>`
   gap: 0.625rem;
   ${font.headline2.medium}
   padding: 0.625rem 2rem;
-  color: ${({ $active, theme }) => ($active ? theme.content.accent : theme.label.normal)};
+  color: ${({ $active, theme }) => ($active ? theme.label.strong : theme.label.normal)};
   cursor: pointer;
   transition: color 0.2s ease;
 

--- a/packages/design-tokens/theme/dark.ts
+++ b/packages/design-tokens/theme/dark.ts
@@ -6,7 +6,7 @@ export const darkTheme: Theme = {
   },
   action: {
     primary: {
-      background: "#c60608",
+      background: "#f1070a",
       foreground: "#fcfcfc",
     },
   },

--- a/packages/design-tokens/theme/light.ts
+++ b/packages/design-tokens/theme/light.ts
@@ -6,7 +6,7 @@ export const lightTheme: Theme = {
   },
   action: {
     primary: {
-      background: "#c60608",
+      background: "#f1070a",
       foreground: "#fcfcfc",
     },
   },


### PR DESCRIPTION
## 변경사항

- dark mode sidebar 활성 label과 icon을 white로 표시합니다.
- Button primary가 기존 red action.primary 토큰을 사용함을 확인했습니다.

## 관련 이슈

Closes #638

## 스크린샷/동영상

## 추가 컨텍스트
