### PR TITLE
feat: skeleton ui/#645

### DIFF
--- a/apps/mac/src/renderer/src/features/attendance/ui/AttendanceDialog.tsx
+++ b/apps/mac/src/renderer/src/features/attendance/ui/AttendanceDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from "@/shared/ui";
+import { Button, Dialog, SkeletonPanel } from "@/shared/ui";
 import { isAttended, type WeeklyAttendanceResponse } from "@/entities/attendance";
 import * as S from "./AttendanceDialog.style";
 
@@ -48,29 +48,20 @@ export const AttendanceDialog = ({
 
     return (
       <Dialog title="출석" width={26} height={33} isOpen={isOpen} onClose={onClose}>
-        <S.LoadState
-          role={hasLoadError ? "alert" : "status"}
-          aria-live={hasLoadError ? "assertive" : "polite"}
-        >
-          <S.GiftIcon aria-hidden />
-          <S.Headline>
-            {isLoading
-              ? "출석 현황을 불러오는 중이에요."
-              : hasLoadError
-                ? "출석 현황을 불러오지 못했어요."
-                : "표시할 출석 현황이 없어요."}
-          </S.Headline>
-          <S.Description>
-            {isLoading
-              ? "잠시만 기다려 주세요."
-              : loadErrorMessage || "잠시 후 다시 확인해 주세요."}
-          </S.Description>
-          {!isLoading && (
+        {isLoading ? (
+          <SkeletonPanel ariaLabel="출석 현황을 불러오는 중" />
+        ) : (
+          <S.LoadState role={hasLoadError ? "alert" : "status"} aria-live="assertive">
+            <S.GiftIcon aria-hidden />
+            <S.Headline>
+              {hasLoadError ? "출석 현황을 불러오지 못했어요." : "표시할 출석 현황이 없어요."}
+            </S.Headline>
+            <S.Description>{loadErrorMessage || "잠시 후 다시 확인해 주세요."}</S.Description>
             <Button variant="primary" size="md" onClick={onRetry}>
               다시 시도
             </Button>
-          )}
-        </S.LoadState>
+          </S.LoadState>
+        )}
       </Dialog>
     );
   }

--- a/apps/mac/src/renderer/src/features/chapter-ranking/ui/ChapterRanking.style.ts
+++ b/apps/mac/src/renderer/src/features/chapter-ranking/ui/ChapterRanking.style.ts
@@ -1,4 +1,4 @@
-import styled, { css, keyframes } from "styled-components";
+import styled, { css } from "styled-components";
 import { font } from "@clash/design-tokens/font";
 import { InlineNotice } from "@clash/ui";
 import FirstFrameIcon from "../assets/first-frame.svg";
@@ -10,25 +10,8 @@ import { DefaultProfileIcon } from "@/shared/ui";
 export type RankingPageEnum = "section" | "chapter";
 export type RankingPositionEnum = "top" | "bottom";
 
-const skeletonWave = keyframes`
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
-  }
-`;
-
 const skeletonBase = css`
-  background: linear-gradient(
-    90deg,
-    ${({ theme }) => theme.fill.normal} 0%,
-    ${({ theme }) => theme.fill.alternative} 50%,
-    ${({ theme }) => theme.fill.normal} 100%
-  );
-  background-size: 200% 100%;
-  animation: ${skeletonWave} 1.6s ease-in-out infinite;
+  background-color: ${({ theme }) => theme.fill.neutral};
 `;
 
 export const RankingContainer = styled.div<{ $page: RankingPageEnum }>`

--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.tsx
@@ -1,6 +1,6 @@
 import * as S from "./MissionContainer.style";
 import { useEffect, useRef, useState } from "react";
-import { SidePanel } from "@/shared/ui";
+import { SidePanel, SkeletonPanel } from "@/shared/ui";
 import { getErrorMessage } from "@/shared/lib";
 import { MarkdownCodeContent } from "@/shared/ui/markdown-code-content/MarkdownCodeContent";
 import type { Mission } from "@/features/chapter/model/chapter.types";
@@ -344,9 +344,7 @@ export const MissionContainer = ({
     }
   };
 
-  const descriptionText = isLoading
-    ? "챕터 정보를 불러오는 중입니다."
-    : description?.trim() || "이 챕터에 대한 설명이 아직 준비되지 않았습니다.";
+  const descriptionText = description?.trim() || "이 챕터에 대한 설명이 아직 준비되지 않았습니다.";
   const isCompletedStage =
     isFinishedSection ||
     (currentStage.totalMissions > 0 && currentStage.currentProgress >= currentStage.totalMissions);
@@ -392,9 +390,13 @@ export const MissionContainer = ({
         ) : (
           <>
             <S.OverviewBody>
-              <S.SectionCard>
-                <S.DescriptionText>{descriptionText}</S.DescriptionText>
-              </S.SectionCard>
+              {isLoading ? (
+                <SkeletonPanel ariaLabel="챕터 정보를 불러오는 중" />
+              ) : (
+                <S.SectionCard>
+                  <S.DescriptionText>{descriptionText}</S.DescriptionText>
+                </S.SectionCard>
+              )}
             </S.OverviewBody>
 
             <S.FooterActions>

--- a/apps/mac/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
+++ b/apps/mac/src/renderer/src/features/competition/ui/rival-competition/battle/Battle.tsx
@@ -1,6 +1,14 @@
 import { useState } from "react";
 import * as S from "./Battle.style";
-import { Button, DefaultProfileIcon, Dialog, Select, SlideSelector } from "@/shared/ui";
+import {
+  Button,
+  DefaultProfileIcon,
+  Dialog,
+  Select,
+  SkeletonPanel,
+  SkeletonRows,
+  SlideSelector,
+} from "@/shared/ui";
 import type { AnalyzeCategory } from "@/entities/competition";
 import { MATCH_VALUE } from "@/entities/competition";
 import { useBattle } from "@/features/competition/model/useBattle";
@@ -69,11 +77,7 @@ export const Battle = () => {
             )}
 
             {battle.queries.info.isPending ? (
-              <S.DetailWrapper>
-                <S.DefaultBattleBox role="status" aria-live="polite">
-                  <S.DefaultBattleText>배틀 정보를 불러오는 중이에요.</S.DefaultBattleText>
-                </S.DefaultBattleBox>
-              </S.DetailWrapper>
+              <SkeletonPanel ariaLabel="배틀 정보를 불러오는 중" />
             ) : battle.queries.info.isError && !battle.battleData ? (
               <S.DetailWrapper>
                 <S.DefaultBattleBox role="alert">
@@ -139,13 +143,7 @@ export const Battle = () => {
 
                 {battle.isBattleSelected ? (
                   battle.queries.detail.isPending || battle.queries.detail.isPlaceholderData ? (
-                    <S.DetailWrapper>
-                      <S.DefaultBattleBox role="status" aria-live="polite">
-                        <S.DefaultBattleText>
-                          배틀 상세 정보를 불러오는 중이에요.
-                        </S.DefaultBattleText>
-                      </S.DefaultBattleBox>
-                    </S.DetailWrapper>
+                    <SkeletonPanel ariaLabel="배틀 상세 정보를 불러오는 중" />
                   ) : battle.queries.detail.isError && !battle.battleDetailData ? (
                     <S.DetailWrapper>
                       <S.DefaultBattleBox role="alert">
@@ -248,9 +246,7 @@ export const Battle = () => {
 
                         {battle.queries.analyze.isPending ||
                         battle.queries.analyze.isPlaceholderData ? (
-                          <S.AnalyzeState role="status" aria-live="polite">
-                            세부 분석을 불러오는 중이에요.
-                          </S.AnalyzeState>
+                          <SkeletonPanel ariaLabel="배틀 세부 분석을 불러오는 중" compact />
                         ) : battle.queries.analyze.isError &&
                           battle.queries.analyze.data === undefined ? (
                           <S.AnalyzeState role="alert">
@@ -379,9 +375,7 @@ export const Battle = () => {
               <S.ModalBody>
                 <S.UserChoiceContainer aria-busy={battle.queries.rivals.isFetching || undefined}>
                   {battle.queries.rivals.isPending ? (
-                    <S.EmptyStateBox role="status" aria-live="polite">
-                      <S.EmptyTitle>신청 가능한 라이벌을 불러오는 중이에요.</S.EmptyTitle>
-                    </S.EmptyStateBox>
+                    <SkeletonRows ariaLabel="신청 가능한 라이벌을 불러오는 중" rows={4} compact />
                   ) : battle.queries.rivals.isError && !battle.battleList ? (
                     <S.EmptyStateBox role="alert">
                       <S.EmptyTitle>신청 가능한 라이벌을 불러오지 못했어요.</S.EmptyTitle>
@@ -475,9 +469,7 @@ export const Battle = () => {
                 aria-busy={battle.queries.applications.isFetching || undefined}
               >
                 {battle.queries.applications.isPending ? (
-                  <S.EmptyStateBox role="status" aria-live="polite">
-                    <S.EmptyTitle>배틀 신청 목록을 불러오는 중이에요.</S.EmptyTitle>
-                  </S.EmptyStateBox>
+                  <SkeletonRows ariaLabel="배틀 신청 목록을 불러오는 중" rows={4} compact />
                 ) : battle.queries.applications.isError && !battle.battleApplyList ? (
                   <S.EmptyStateBox role="alert">
                     <S.EmptyTitle>배틀 신청 목록을 불러오지 못했어요.</S.EmptyTitle>

--- a/apps/mac/src/renderer/src/features/group/ui/group-side-tab/panel/GroupFormPanel.tsx
+++ b/apps/mac/src/renderer/src/features/group/ui/group-side-tab/panel/GroupFormPanel.tsx
@@ -1,4 +1,4 @@
-import { Button, SlideSelector } from "@/shared/ui";
+import { Button, SkeletonCards, SlideSelector } from "@/shared/ui";
 import { GROUP_CATEGORY_LABELS } from "@/entities/group";
 import type { GroupFormPanelProps } from "../../../model/useGroup";
 import { useGroupFormPanel } from "../../../model/useGroupFormPanel";
@@ -78,9 +78,11 @@ export const GroupFormPanel = ({
 
               <S.GroupsWrapper>
                 {isLoading ? (
-                  <S.EmptyState>
-                    <S.EmptyTitle>로딩 중...</S.EmptyTitle>
-                  </S.EmptyState>
+                  <SkeletonCards
+                    ariaLabel="참여할 수 있는 그룹을 불러오는 중"
+                    cards={4}
+                    columns={1}
+                  />
                 ) : groups.length === 0 ? (
                   <S.EmptyState>
                     <S.EmptyTextBox>

--- a/apps/mac/src/renderer/src/features/home/ui/ranking/Ranking.tsx
+++ b/apps/mac/src/renderer/src/features/home/ui/ranking/Ranking.tsx
@@ -1,7 +1,7 @@
 import * as S from "./Ranking.style";
 import { rankingRewardTooltipContent } from "./Ranking.constants";
 import { useRanking } from "@/features/home/model/useRanking";
-import { Button, Select, QuestionTooltip } from "@/shared/ui";
+import { Button, Select, QuestionTooltip, SkeletonRows } from "@/shared/ui";
 import type { CategoryType, PeriodType, RankingItem } from "@/entities/ranking";
 import { UserRanking } from "./user-ranking/UserRanking";
 
@@ -58,15 +58,14 @@ export const Ranking = () => {
       <S.UserWrapper>
         <S.UserContainer ref={wrapperRef} aria-busy={domain.isFetching}>
           {domain.isLoading || domain.isPlaceholderData ? (
-            <S.DetailWrapper>
-              <S.DefaultBattleBox role="status" aria-live="polite">
-                <S.DefaultBattleText>
-                  {domain.isPlaceholderData
-                    ? "선택한 조건의 랭킹을 불러오는 중이에요."
-                    : "랭킹을 불러오는 중이에요."}
-                </S.DefaultBattleText>
-              </S.DefaultBattleBox>
-            </S.DetailWrapper>
+            <SkeletonRows
+              ariaLabel={
+                domain.isPlaceholderData ? "선택한 조건의 랭킹을 불러오는 중" : "랭킹을 불러오는 중"
+              }
+              rows={6}
+              surface
+              compact
+            />
           ) : domain.isError && !hasRankings ? (
             <S.DetailWrapper>
               <S.DefaultBattleBox role="alert">

--- a/apps/mac/src/renderer/src/features/major-choice/ui/test/Test.tsx
+++ b/apps/mac/src/renderer/src/features/major-choice/ui/test/Test.tsx
@@ -1,6 +1,7 @@
 import * as S from "./Test.style";
 import type { TestProps } from "@/features/major-choice/model/useMajorChoice";
 import { Button } from "@/shared/ui/button";
+import { SkeletonRows } from "@/shared/ui/skeleton";
 import { AGREEMENT_LABELS, LevelSlider } from "@/shared/ui/level-slider";
 import type { LevelSliderValue } from "@/shared/ui/level-slider/types";
 
@@ -61,9 +62,13 @@ export const Test = ({
         </S.StickyHeader>
         <S.QuestionWrapper>
           {isQuestionsLoading ? (
-            <S.StateBox role="status" aria-live="polite">
-              <S.StateTitle>검사 문항을 불러오는 중이에요.</S.StateTitle>
-            </S.StateBox>
+            <SkeletonRows
+              ariaLabel="검사 문항을 불러오는 중"
+              rows={4}
+              showAvatar={false}
+              showTrailing={false}
+              surface
+            />
           ) : questionsError && questionData.length === 0 ? (
             <S.StateBox role="alert">
               <S.StateTitle>검사 문항을 불러오지 못했어요.</S.StateTitle>

--- a/apps/mac/src/renderer/src/features/notice/ui/TopbarNotice.tsx
+++ b/apps/mac/src/renderer/src/features/notice/ui/TopbarNotice.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { formatNoticeDate, useTopbarNotice } from "@/features/notice/model/useTopbarNotice";
-import { Button, Popover } from "@/shared/ui";
+import { Button, Popover, SkeletonRows } from "@/shared/ui";
 import * as S from "./TopbarNotice.style";
 import { getErrorMessage } from "@/shared/lib";
 
@@ -157,9 +157,7 @@ export const TopbarNotice = () => {
               </S.BackgroundErrorNotice>
             )}
             {isLoading ? (
-              <S.NoneNotice role="status" aria-live="polite">
-                알림을 불러오는 중입니다.
-              </S.NoneNotice>
+              <SkeletonRows ariaLabel="알림을 불러오는 중" rows={4} showTrailing compact />
             ) : isError && !hasQueryData ? (
               <S.NoticeState role="alert">
                 <span>{getErrorMessage(error, "알림을 불러오지 못했어요.")}</span>

--- a/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/github-activity-panel/GitHubActivityPanel.tsx
+++ b/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/github-activity-panel/GitHubActivityPanel.tsx
@@ -3,6 +3,7 @@ import { GitHubInfo } from "@/features/profile/ui/profile-tabs/github-info/GitHu
 import { GitHubStreak } from "@/features/profile/ui/profile-tabs/github-streak/GitHubStreak";
 import { useProfileGitHubDetailQuery } from "@/entities/profile";
 import { useProfileGitHubStreak } from "@/features/profile/model/useProfileTabs";
+import { SkeletonPanel } from "@/shared/ui";
 import * as S from "./GitHubActivityPanel.style";
 
 const formatKoreanDate = (ymd: string) => {
@@ -73,13 +74,17 @@ export const GitHubActivityPanel = () => {
       </S.StreakSection>
 
       <S.InfoSection>
-        <GitHubInfo
-          {...infoProps}
-          showSummary={hasSelection}
-          hasDetail={Boolean(selectedDate && displayDetail)}
-          emptyTitle={emptyTitle}
-          emptyDescription={emptyDescription}
-        />
+        {selectedDate && !displayDetail && (detailQuery.isFetching || detailQuery.isLoading) ? (
+          <SkeletonPanel ariaLabel="선택한 날짜의 GitHub 활동을 불러오는 중" />
+        ) : (
+          <GitHubInfo
+            {...infoProps}
+            showSummary={hasSelection}
+            hasDetail={Boolean(selectedDate && displayDetail)}
+            emptyTitle={emptyTitle}
+            emptyDescription={emptyDescription}
+          />
+        )}
       </S.InfoSection>
     </S.Panel>
   );

--- a/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/item-panel/ItemPanel.tsx
+++ b/apps/mac/src/renderer/src/features/profile/ui/profile-tabs/item-panel/ItemPanel.tsx
@@ -12,7 +12,7 @@ import {
 import { sortEquippedItemsFirst } from "@/features/profile/lib/sortEquippedItemsFirst";
 import { useGetMyProfile, userQueryKeys } from "@/entities/user";
 import { getErrorMessage } from "@/shared/lib";
-import { Button } from "@/shared/ui";
+import { Button, SkeletonCards } from "@/shared/ui";
 
 const FILTER_OPTIONS = [
   { key: OwnedItemCategory.ALL, label: "전체" },
@@ -126,10 +126,7 @@ export const ItemPanel = () => {
             </Button>
           </S.StateBox>
         ) : isLoading ? (
-          <S.StateBox role="status" aria-live="polite" aria-busy="true">
-            <S.StateTitle>아이템을 불러오는 중...</S.StateTitle>
-            <S.StateDescription>잠시만 기다려 주세요.</S.StateDescription>
-          </S.StateBox>
+          <SkeletonCards ariaLabel="보유한 아이템을 불러오는 중" cards={8} columns={4} />
         ) : items.length === 0 ? (
           <S.StateBox>
             <S.StateTitle>보유한 아이템이 아직 없어요.</S.StateTitle>

--- a/apps/mac/src/renderer/src/features/record/ui/task/Task.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/task/Task.tsx
@@ -1,7 +1,7 @@
 import * as S from "./Task.style";
 import { formatTime, getErrorMessage } from "@/shared/lib";
 import { useTaskList } from "../../model/useTaskList";
-import { Button, ConfirmDialog, Popover, Tooltip } from "@/shared/ui";
+import { Button, ConfirmDialog, Popover, SkeletonRows, Tooltip } from "@/shared/ui";
 
 interface TaskProps {
   selectedDate?: string;
@@ -74,7 +74,7 @@ export const Task = ({ selectedDate }: TaskProps) => {
       <S.TaskContainer>
         <S.TaskBox aria-busy={subjectsQuery.isFetching || undefined}>
           {subjectsQuery.isPending ? (
-            <S.ListState kind="loading">과목을 불러오는 중이에요.</S.ListState>
+            <SkeletonRows ariaLabel="과목을 불러오는 중" rows={5} showAvatar={false} compact />
           ) : hasInitialLoadError ? (
             <S.ListState kind="error">
               <span>{getErrorMessage(subjectsQuery.error, "과목을 불러오지 못했어요.")}</span>

--- a/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/timer/Timer.tsx
@@ -2,6 +2,7 @@ import * as S from "./Timer.style";
 import { formatTime } from "@/shared/lib";
 import { useRecordStore } from "../../model/recordStore";
 import { useLiveRecordStudyTime } from "../../model/useLiveRecordStudyTime";
+import { Skeleton } from "@/shared/ui";
 
 interface TimerProps {
   date: string;
@@ -103,7 +104,7 @@ export const Timer = ({
           aria-label={isLoading ? "총 학습 시간을 불러오는 중" : `총 학습 시간 ${displayTime}`}
           $loading={isLoading}
         >
-          {displayTime}
+          {isLoading ? <Skeleton width="8ch" height="2.75rem" radius="0.5rem" /> : displayTime}
         </S.Time>
         {stopButtonPosition === "RIGHT" && stopButton}
       </S.TimeBox>

--- a/apps/mac/src/renderer/src/features/record/ui/todo/Todo.tsx
+++ b/apps/mac/src/renderer/src/features/record/ui/todo/Todo.tsx
@@ -1,4 +1,4 @@
-import { Button, Popover, Select, Tooltip } from "@/shared/ui";
+import { Button, Popover, Select, SkeletonRows, Tooltip } from "@/shared/ui";
 import * as S from "./Todo.style";
 import { useTodoList } from "../../model/useTodoList";
 import { getErrorMessage } from "@/shared/lib";
@@ -84,7 +84,7 @@ export const Todo = ({ selectedDate }: TodoProps) => {
             </S.SourceNotice>
           )}
           {tasksQuery.isPending ? (
-            <S.ListState kind="loading">할 일을 불러오는 중이에요.</S.ListState>
+            <SkeletonRows ariaLabel="할 일을 불러오는 중" rows={5} showAvatar={false} compact />
           ) : hasInitialTasksError ? (
             <S.ListState kind="error">
               <span>{getErrorMessage(tasksQuery.error, "할 일을 불러오지 못했어요.")}</span>

--- a/apps/mac/src/renderer/src/features/rival-management/ui/rivals-management/RivalsManagement.tsx
+++ b/apps/mac/src/renderer/src/features/rival-management/ui/rivals-management/RivalsManagement.tsx
@@ -1,6 +1,6 @@
 import { useState, type ChangeEvent } from "react";
 import * as S from "./RivalsManagement.style";
-import { Button } from "@/shared/ui/button";
+import { Button, SkeletonRows } from "@/shared/ui";
 import { Dialog } from "@/shared/ui/dialog";
 import { SearchInput } from "@/shared/ui/search-input";
 import { SlideSelector } from "@/shared/ui/slide-selector";
@@ -80,9 +80,7 @@ export const RivalsManagementDialog = ({ isOpen, onClose, rival }: AddRivalsDial
               </S.SearchInputBox>
 
               {rival.queries.myRivals.isPending ? (
-                <S.EmptyStateBox role="status" aria-live="polite">
-                  <S.EmptyTitle>현재 라이벌 정보를 확인하는 중이에요.</S.EmptyTitle>
-                </S.EmptyStateBox>
+                <SkeletonRows ariaLabel="현재 라이벌 정보를 확인하는 중" rows={4} compact />
               ) : rival.queries.myRivals.isError ? (
                 <S.EmptyStateBox role="alert">
                   <S.EmptyTitle>현재 라이벌 정보를 확인하지 못했어요.</S.EmptyTitle>
@@ -99,9 +97,7 @@ export const RivalsManagementDialog = ({ isOpen, onClose, rival }: AddRivalsDial
                   </Button>
                 </S.EmptyStateBox>
               ) : rival.queries.available.isPending ? (
-                <S.EmptyStateBox role="status" aria-live="polite">
-                  <S.EmptyTitle>추가할 수 있는 라이벌을 불러오는 중이에요.</S.EmptyTitle>
-                </S.EmptyStateBox>
+                <SkeletonRows ariaLabel="추가할 수 있는 라이벌을 불러오는 중" rows={4} compact />
               ) : rival.queries.available.isError ? (
                 <S.EmptyStateBox role="alert">
                   <S.EmptyTitle>라이벌 목록을 불러오지 못했어요.</S.EmptyTitle>
@@ -204,9 +200,7 @@ export const RivalsManagementDialog = ({ isOpen, onClose, rival }: AddRivalsDial
 
               <S.UserChoiceContainer>
                 {rival.queries.myRivals.isPending ? (
-                  <S.EmptyStateBox role="status" aria-live="polite">
-                    <S.EmptyTitle>현재 라이벌을 불러오는 중이에요.</S.EmptyTitle>
-                  </S.EmptyStateBox>
+                  <SkeletonRows ariaLabel="현재 라이벌을 불러오는 중" rows={4} compact />
                 ) : rival.queries.myRivals.isError && !rival.rivalsData ? (
                   <S.EmptyStateBox role="alert">
                     <S.EmptyTitle>현재 라이벌을 불러오지 못했어요.</S.EmptyTitle>
@@ -268,9 +262,7 @@ export const RivalsManagementDialog = ({ isOpen, onClose, rival }: AddRivalsDial
               <S.DetermineList>
                 <S.UserChoiceContainer>
                   {rival.queries.requests.isPending ? (
-                    <S.EmptyStateBox role="status" aria-live="polite">
-                      <S.EmptyTitle>라이벌 신청 목록을 불러오는 중이에요.</S.EmptyTitle>
-                    </S.EmptyStateBox>
+                    <SkeletonRows ariaLabel="라이벌 신청 목록을 불러오는 중" rows={4} compact />
                   ) : rival.queries.requests.isError && !rival.rivalSignAll ? (
                     <S.EmptyStateBox role="alert">
                       <S.EmptyTitle>라이벌 신청 목록을 불러오지 못했어요.</S.EmptyTitle>

--- a/apps/mac/src/renderer/src/features/section-progress/ui/SectionProgress.tsx
+++ b/apps/mac/src/renderer/src/features/section-progress/ui/SectionProgress.tsx
@@ -1,7 +1,7 @@
 import * as S from "./SectionProgress.style";
 import { useGetMyProfile } from "@/entities/user";
 import { MajorEnum, useMajorSectionQuery } from "@/entities/roadmap";
-import { Button } from "@/shared/ui";
+import { Button, SkeletonPanel } from "@/shared/ui";
 
 interface SectionProgressProps {
   completed?: number;
@@ -25,10 +25,8 @@ export const SectionProgress = ({
 
   if (needsRemoteCounts && (profileQuery.isLoading || sectionQuery.isLoading)) {
     return (
-      <S.SectionProgressContainer role="status" aria-live="polite">
-        <S.StateContent>
-          <S.StateMessage>진행률을 불러오는 중이에요.</S.StateMessage>
-        </S.StateContent>
+      <S.SectionProgressContainer>
+        <SkeletonPanel ariaLabel="로드맵 진행률을 불러오는 중" compact />
       </S.SectionProgressContainer>
     );
   }

--- a/apps/mac/src/renderer/src/features/section/components/PreviewModal.style.ts
+++ b/apps/mac/src/renderer/src/features/section/components/PreviewModal.style.ts
@@ -1,4 +1,4 @@
-import styled, { css, keyframes } from "styled-components";
+import styled, { css } from "styled-components";
 import { font } from "@clash/design-tokens/font";
 import { palette } from "@clash/design-tokens/theme";
 import Check from "@/shared/ui/assets/check.svg";
@@ -7,25 +7,8 @@ import Flag from "../assets/flag.svg";
 import Arrow from "../assets/arrow.svg";
 import Star from "../assets/star.svg";
 
-const skeletonWave = keyframes`
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
-  }
-`;
-
 const skeletonBase = css`
-  background: linear-gradient(
-    90deg,
-    ${({ theme }) => theme.fill.normal} 0%,
-    ${({ theme }) => theme.fill.alternative} 50%,
-    ${({ theme }) => theme.fill.normal} 100%
-  );
-  background-size: 200% 100%;
-  animation: ${skeletonWave} 1.6s ease-in-out infinite;
+  background-color: ${({ theme }) => theme.fill.neutral};
 `;
 
 export const PreviewModalWrapper = styled.div`

--- a/apps/mac/src/renderer/src/pages/competition/rival/RivalCompetitionPage.tsx
+++ b/apps/mac/src/renderer/src/pages/competition/rival/RivalCompetitionPage.tsx
@@ -1,7 +1,7 @@
 import * as S from "./RivalCompetitionPage.style";
 import { RivalCompetition } from "@/features/competition";
 import { RivalsManagementDialog, useRival } from "@/features/rival-management";
-import { Button } from "@/shared/ui";
+import { Button, SkeletonPanel } from "@/shared/ui";
 import { getErrorMessage } from "@/shared/lib";
 
 export const RivalCompetitionPage = () => {
@@ -24,9 +24,7 @@ export const RivalCompetitionPage = () => {
         </S.RefreshNotice>
       )}
       {rival.queries.myRivals.isPending ? (
-        <S.EmptyState role="status" aria-live="polite">
-          <S.EmptyText>라이벌 경쟁 정보를 불러오는 중이에요.</S.EmptyText>
-        </S.EmptyState>
+        <SkeletonPanel ariaLabel="라이벌 경쟁 정보를 불러오는 중" />
       ) : rival.queries.myRivals.isError && !rival.rivalsData ? (
         <S.EmptyState role="alert">
           <S.EmptyText>

--- a/apps/mac/src/renderer/src/pages/group/GroupPage.style.ts
+++ b/apps/mac/src/renderer/src/pages/group/GroupPage.style.ts
@@ -19,6 +19,134 @@ export const Content = styled.div`
   min-height: 0;
 `;
 
+export const ActivitySkeleton = styled.div`
+  display: flex;
+  flex: 2;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  background-color: ${({ theme }) => theme.background.normal};
+`;
+
+export const ActivityHeaderSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0 1.5rem;
+`;
+
+export const TimerSkeleton = styled.div`
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const StudySummarySkeleton = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.875rem;
+`;
+
+export const ActivityBodySkeleton = styled.div`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 2.5rem;
+`;
+
+export const GroupInfoSkeleton = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+`;
+
+export const GroupStatsSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+`;
+
+export const MemberGridSkeleton = styled.div`
+  display: grid;
+  flex: 1;
+  min-height: 0;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-content: start;
+  column-gap: 1rem;
+  row-gap: 1.25rem;
+  overflow: hidden;
+`;
+
+export const MemberSkeleton = styled.div`
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const GroupSideSkeleton = styled.div`
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background-color: ${({ theme }) => theme.background.normal};
+`;
+
+export const GroupSideHeaderSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+`;
+
+export const GroupListSkeleton = styled.div`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  margin-top: 1rem;
+  padding-bottom: 4rem;
+  overflow: hidden;
+`;
+
+export const GroupListItemSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  padding: 1.25rem 0.75rem;
+  border-bottom: 2px solid ${({ theme }) => theme.fill.alternative};
+`;
+
+export const GroupListItemLeftSkeleton = styled.div`
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+export const GroupListItemRightSkeleton = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
 export const PageState = styled.div`
   display: flex;
   flex: 1;

--- a/apps/mac/src/renderer/src/pages/group/GroupPage.tsx
+++ b/apps/mac/src/renderer/src/pages/group/GroupPage.tsx
@@ -6,6 +6,7 @@ import { shiftRecordDate, useTodayRecordDate } from "@/features/record";
 import { GroupActivity } from "@/widgets/group-activity";
 import { Button } from "@/shared/ui";
 import { getErrorMessage } from "@/shared/lib";
+import { GroupPageSkeleton } from "./GroupPageSkeleton";
 
 export const GroupPage = () => {
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
@@ -38,10 +39,7 @@ export const GroupPage = () => {
   if (isGroupsPending && !myGroupsResponse) {
     return (
       <S.GroupPageContainer>
-        <S.PageState role="status" aria-live="polite" aria-busy="true">
-          <S.PageStateTitle>그룹을 불러오는 중이에요.</S.PageStateTitle>
-          <S.PageStateDescription>잠시만 기다려 주세요.</S.PageStateDescription>
-        </S.PageState>
+        <GroupPageSkeleton />
       </S.GroupPageContainer>
     );
   }

--- a/apps/mac/src/renderer/src/pages/group/GroupPageSkeleton.tsx
+++ b/apps/mac/src/renderer/src/pages/group/GroupPageSkeleton.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from "@/shared/ui";
+import * as S from "./GroupPage.style";
+
+const memberSkeletons = Array.from({ length: 10 }, (_, index) => (
+  <S.MemberSkeleton key={index} aria-hidden="true">
+    <Skeleton width="2.75rem" height="2.75rem" radius="999px" />
+    <Skeleton width={index % 2 === 0 ? "3.5rem" : "3rem"} height="0.85rem" />
+    <Skeleton width="4.25rem" height="0.7rem" />
+  </S.MemberSkeleton>
+));
+
+const groupSkeletons = Array.from({ length: 5 }, (_, index) => (
+  <S.GroupListItemSkeleton key={index} aria-hidden="true">
+    <S.GroupListItemLeftSkeleton>
+      <Skeleton width="1.5rem" height="1.5rem" radius="999px" />
+      <Skeleton width={index % 2 === 0 ? "7rem" : "5.5rem"} height="1rem" />
+    </S.GroupListItemLeftSkeleton>
+    <S.GroupListItemRightSkeleton>
+      <Skeleton width="3.25rem" height="0.85rem" />
+      <Skeleton width="1.5rem" height="1.5rem" radius="0.375rem" />
+    </S.GroupListItemRightSkeleton>
+  </S.GroupListItemSkeleton>
+));
+
+export const GroupPageSkeleton = () => (
+  <S.Content role="status" aria-live="polite" aria-label="그룹 페이지를 불러오는 중">
+    <S.ActivitySkeleton>
+      <S.ActivityHeaderSkeleton aria-hidden="true">
+        <S.TimerSkeleton>
+          <Skeleton width="7rem" height="1rem" />
+          <Skeleton width="10rem" height="3rem" radius="0.75rem" />
+        </S.TimerSkeleton>
+        <S.StudySummarySkeleton>
+          <Skeleton width="4rem" height="4rem" radius="999px" />
+          <Skeleton width="6rem" height="1.25rem" />
+        </S.StudySummarySkeleton>
+      </S.ActivityHeaderSkeleton>
+
+      <S.ActivityBodySkeleton>
+        <S.GroupInfoSkeleton aria-hidden="true">
+          <Skeleton width="9rem" height="1.25rem" />
+          <S.GroupStatsSkeleton>
+            <Skeleton width="6.5rem" height="1rem" />
+            <Skeleton width="4rem" height="1rem" />
+          </S.GroupStatsSkeleton>
+        </S.GroupInfoSkeleton>
+        <S.MemberGridSkeleton>{memberSkeletons}</S.MemberGridSkeleton>
+      </S.ActivityBodySkeleton>
+    </S.ActivitySkeleton>
+
+    <S.GroupSideSkeleton>
+      <S.GroupSideHeaderSkeleton aria-hidden="true">
+        <Skeleton width="6rem" height="1.25rem" />
+        <Skeleton width="1.5rem" height="1.5rem" radius="0.375rem" />
+      </S.GroupSideHeaderSkeleton>
+      <S.GroupListSkeleton>{groupSkeletons}</S.GroupListSkeleton>
+    </S.GroupSideSkeleton>
+  </S.Content>
+);

--- a/apps/mac/src/renderer/src/pages/home/ui/Home.tsx
+++ b/apps/mac/src/renderer/src/pages/home/ui/Home.tsx
@@ -3,8 +3,7 @@ import { Active, Ranking, Transition } from "@/features/home";
 import { Rival } from "@/widgets/home-rivals";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { Dialog } from "@/shared/ui";
-import { Skeleton } from "@/shared/ui/skeleton";
+import { DashboardCardSkeleton, Dialog } from "@/shared/ui";
 import * as S from "./Home.style";
 import {
   activeQueryKeys,
@@ -103,10 +102,10 @@ export const Home = () => {
   if (isChecking) {
     return (
       <>
-        <Skeleton />
-        <Skeleton />
-        <Skeleton />
-        <Skeleton />
+        <DashboardCardSkeleton ariaLabel="홈 정보를 불러오는 중" />
+        <DashboardCardSkeleton />
+        <DashboardCardSkeleton />
+        <DashboardCardSkeleton />
       </>
     );
   }
@@ -114,10 +113,10 @@ export const Home = () => {
   if (isGitHubNotReady) {
     return (
       <>
-        <Skeleton />
-        <Skeleton />
-        <Skeleton />
-        <Skeleton />
+        <DashboardCardSkeleton ariaLabel="GitHub 활동 정보를 준비하는 중" />
+        <DashboardCardSkeleton />
+        <DashboardCardSkeleton />
+        <DashboardCardSkeleton />
         {!isGitHubNotLinked && (
           <Dialog width={21.5} height={21.5} isOpen={true} ariaLabel="GitHub 계정 연동 중">
             <S.ConnectingContainer>

--- a/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
+++ b/apps/mac/src/renderer/src/pages/roadmap/chapter/ChapterPage.tsx
@@ -6,6 +6,7 @@ import { MissionContainer, Roadmap, useChapter } from "@/features/chapter";
 import { MajorEnum, useMajorSectionQuery } from "@/entities/roadmap";
 import { useEffect, useMemo } from "react";
 import { useGetMyProfile } from "@/entities/user";
+import { SkeletonPanel } from "@/shared/ui";
 
 export const ChapterPage = () => {
   const { sectionId } = useParams<{ sectionId: string }>();
@@ -76,7 +77,9 @@ export const ChapterPage = () => {
       <S.ChapterContainer>
         <S.ChapterScrollable ref={chapterRef} {...chapterScrollProps}>
           <S.ChapterCanvas />
-          <S.CenteredStatusMessage>로딩 중..</S.CenteredStatusMessage>
+          <S.CenteredStatusMessage>
+            <SkeletonPanel ariaLabel="챕터 로드맵을 불러오는 중" />
+          </S.CenteredStatusMessage>
         </S.ChapterScrollable>
       </S.ChapterContainer>
     );

--- a/apps/mac/src/renderer/src/shared/ui/index.ts
+++ b/apps/mac/src/renderer/src/shared/ui/index.ts
@@ -41,3 +41,11 @@ export type { ProfileAvatarProps } from "./profile-avatar";
 export { NameTag } from "./name-tag";
 export type { NameTagProps, NameTagSize, NameTagTextAlign, NameTagWidth } from "./name-tag";
 export { ClashLoadingIcon } from "./clash-loading-icon/ClashLoadingIcon";
+export {
+  DashboardCardSkeleton,
+  Skeleton,
+  SkeletonCards,
+  SkeletonPanel,
+  SkeletonRows,
+} from "./skeleton";
+export type { SkeletonProps } from "./skeleton";

--- a/apps/mac/src/renderer/src/shared/ui/skeleton/Skeleton.style.ts
+++ b/apps/mac/src/renderer/src/shared/ui/skeleton/Skeleton.style.ts
@@ -1,21 +1,133 @@
-import styled from "styled-components";
+import type { CSSProperties } from "react";
+import styled, { css } from "styled-components";
 
-export const SkeletonContainer = styled.div`
-  width: 100%;
-  height: 100%;
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: start;
-  justify-content: start;
-  background-color: ${({ theme }) => theme.background.normal};
-  border-radius: 1rem;
-  gap: 1rem;
+const skeletonSurface = css`
+  background-color: ${({ theme }) => theme.fill.neutral};
 `;
 
-export const SkeletonBox = styled.div<{ $width: number; $height: number }>`
-  width: ${({ $width }) => $width}%;
-  height: ${({ $height }) => $height}%;
-  background-color: ${({ theme }) => theme.fill.neutral};
-  border-radius: 0.5rem;
+export const SkeletonBlock = styled.span<{
+  $width: CSSProperties["width"];
+  $height: CSSProperties["height"];
+  $radius: CSSProperties["borderRadius"];
+}>`
+  ${skeletonSurface};
+  display: block;
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
+  min-width: 0;
+  border-radius: ${({ $radius }) => $radius};
+  flex-shrink: 0;
+`;
+
+export const SkeletonStatus = styled.div`
+  display: flex;
+  flex: 1;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const SkeletonRow = styled.div<{ $surface: boolean; $compact: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ $compact }) => ($compact ? "0.625rem" : "0.875rem")};
+  width: 100%;
+  min-width: 0;
+  min-height: ${({ $compact }) => ($compact ? "3.5rem" : "4.75rem")};
+  padding: ${({ $compact }) => ($compact ? "0.625rem 0.75rem" : "0.875rem 1rem")};
+  box-sizing: border-box;
+  border-radius: 0.75rem;
+  background-color: ${({ $surface, theme }) =>
+    $surface ? theme.background.alternative : "transparent"};
+`;
+
+export const SkeletonTextGroup = styled.div`
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const SkeletonCardGrid = styled.div<{ $columns: number }>`
+  display: grid;
+  flex: 1;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  grid-template-columns: repeat(${({ $columns }) => $columns}, minmax(0, 1fr));
+  gap: 1rem;
+  overflow-y: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (max-width: 48rem) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const SkeletonCard = styled.div`
+  display: flex;
+  min-width: 0;
+  min-height: 7.5rem;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background-color: ${({ theme }) => theme.background.alternative};
+`;
+
+export const SkeletonCardHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+`;
+
+export const SkeletonPanel = styled.div<{ $compact: boolean }>`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  min-height: ${({ $compact }) => ($compact ? "3rem" : "10rem")};
+  flex-direction: column;
+  justify-content: center;
+  gap: ${({ $compact }) => ($compact ? "0.625rem" : "1rem")};
+  padding: ${({ $compact }) => ($compact ? "0.5rem 0.75rem" : "1.5rem")};
+  box-sizing: border-box;
+  border-radius: 0.75rem;
+  background-color: ${({ theme }) => theme.background.alternative};
+`;
+
+export const DashboardCardSkeleton = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  border-radius: 1rem;
+  background-color: ${({ theme }) => theme.background.normal};
+`;
+
+export const DashboardSkeletonRow = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 0;
 `;

--- a/apps/mac/src/renderer/src/shared/ui/skeleton/Skeleton.tsx
+++ b/apps/mac/src/renderer/src/shared/ui/skeleton/Skeleton.tsx
@@ -1,10 +1,127 @@
+import type { CSSProperties, HTMLAttributes } from "react";
 import * as S from "./Skeleton.style";
 
-export const Skeleton = () => {
-  return (
-    <S.SkeletonContainer>
-      <S.SkeletonBox $width={80} $height={15} />
-      <S.SkeletonBox $width={40} $height={15} />
-    </S.SkeletonContainer>
-  );
-};
+export interface SkeletonProps extends Omit<HTMLAttributes<HTMLSpanElement>, "children"> {
+  width?: CSSProperties["width"];
+  height?: CSSProperties["height"];
+  radius?: CSSProperties["borderRadius"];
+}
+
+export const Skeleton = ({
+  width = "100%",
+  height = "1rem",
+  radius = "0.5rem",
+  ...props
+}: SkeletonProps) => (
+  <S.SkeletonBlock aria-hidden="true" $width={width} $height={height} $radius={radius} {...props} />
+);
+
+interface SkeletonRowsProps {
+  ariaLabel: string;
+  rows?: number;
+  showAvatar?: boolean;
+  showTrailing?: boolean;
+  surface?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+export const SkeletonRows = ({
+  ariaLabel,
+  rows = 4,
+  showAvatar = true,
+  showTrailing = true,
+  surface = false,
+  compact = false,
+  className,
+}: SkeletonRowsProps) => (
+  <S.SkeletonStatus className={className} role="status" aria-live="polite" aria-label={ariaLabel}>
+    {Array.from({ length: rows }, (_, index) => (
+      <S.SkeletonRow key={index} $surface={surface} $compact={compact} aria-hidden="true">
+        {showAvatar && <Skeleton width="2.5rem" height="2.5rem" radius="999px" />}
+        <S.SkeletonTextGroup>
+          <Skeleton width={index % 2 === 0 ? "58%" : "46%"} height="0.95rem" />
+          <Skeleton width={index % 3 === 0 ? "38%" : "30%"} height="0.7rem" />
+        </S.SkeletonTextGroup>
+        {showTrailing && <Skeleton width="3.75rem" height="1.5rem" radius="0.75rem" />}
+      </S.SkeletonRow>
+    ))}
+  </S.SkeletonStatus>
+);
+
+interface SkeletonCardsProps {
+  ariaLabel: string;
+  cards?: number;
+  columns?: number;
+  className?: string;
+}
+
+export const SkeletonCards = ({
+  ariaLabel,
+  cards = 4,
+  columns = 2,
+  className,
+}: SkeletonCardsProps) => (
+  <S.SkeletonCardGrid
+    className={className}
+    role="status"
+    aria-live="polite"
+    aria-label={ariaLabel}
+    $columns={columns}
+  >
+    {Array.from({ length: cards }, (_, index) => (
+      <S.SkeletonCard key={index} aria-hidden="true">
+        <S.SkeletonCardHeader>
+          <Skeleton width="2.5rem" height="2.5rem" radius="999px" />
+          <S.SkeletonTextGroup>
+            <Skeleton width={index % 2 === 0 ? "62%" : "52%"} height="1rem" />
+            <Skeleton width="38%" height="0.7rem" />
+          </S.SkeletonTextGroup>
+        </S.SkeletonCardHeader>
+        <Skeleton width="100%" height="3rem" radius="0.75rem" />
+      </S.SkeletonCard>
+    ))}
+  </S.SkeletonCardGrid>
+);
+
+interface SkeletonPanelProps {
+  ariaLabel?: string;
+  className?: string;
+  compact?: boolean;
+}
+
+export const SkeletonPanel = ({ ariaLabel, className, compact = false }: SkeletonPanelProps) => (
+  <S.SkeletonPanel
+    className={className}
+    role={ariaLabel ? "status" : undefined}
+    aria-live={ariaLabel ? "polite" : undefined}
+    aria-label={ariaLabel}
+    aria-hidden={ariaLabel ? undefined : "true"}
+    $compact={compact}
+  >
+    <Skeleton width="32%" height={compact ? "1rem" : "1.5rem"} />
+    <Skeleton width="100%" height={compact ? "0.75rem" : "2.75rem"} radius="0.75rem" />
+    <Skeleton width="78%" height={compact ? "0.75rem" : "1rem"} />
+    {!compact && <Skeleton width="54%" height="1rem" />}
+  </S.SkeletonPanel>
+);
+
+interface DashboardCardSkeletonProps {
+  ariaLabel?: string;
+}
+
+export const DashboardCardSkeleton = ({ ariaLabel }: DashboardCardSkeletonProps) => (
+  <S.DashboardCardSkeleton
+    role={ariaLabel ? "status" : undefined}
+    aria-live={ariaLabel ? "polite" : undefined}
+    aria-label={ariaLabel}
+  >
+    <Skeleton width="34%" height="1.5rem" />
+    <Skeleton width="100%" height="1px" radius="0" />
+    <Skeleton width="100%" height="42%" radius="0.75rem" />
+    <S.DashboardSkeletonRow>
+      <Skeleton width="45%" height="28%" radius="0.75rem" />
+      <Skeleton width="45%" height="28%" radius="0.75rem" />
+    </S.DashboardSkeletonRow>
+  </S.DashboardCardSkeleton>
+);

--- a/apps/mac/src/renderer/src/shared/ui/skeleton/index.ts
+++ b/apps/mac/src/renderer/src/shared/ui/skeleton/index.ts
@@ -1,1 +1,8 @@
-export { Skeleton } from "./Skeleton";
+export {
+  DashboardCardSkeleton,
+  Skeleton,
+  SkeletonCards,
+  SkeletonPanel,
+  SkeletonRows,
+} from "./Skeleton";
+export type { SkeletonProps } from "./Skeleton";

--- a/apps/mac/src/renderer/src/widgets/group-activity/ui/GroupActivity.tsx
+++ b/apps/mac/src/renderer/src/widgets/group-activity/ui/GroupActivity.tsx
@@ -3,7 +3,7 @@ import { type Group as GroupEntity } from "@/entities/group";
 import { formatTime } from "@/shared/lib";
 import { useGroupRealtimeActivity } from "../model/useGroupRealtimeActivity";
 import { Timer } from "@/features/record";
-import { Button } from "@/shared/ui";
+import { Button, Skeleton, SkeletonRows } from "@/shared/ui";
 import { getErrorMessage } from "@/shared/lib";
 
 interface GroupProps {
@@ -67,7 +67,11 @@ export const GroupActivity = ({
                 <S.MyStudySummary $isActive={isStudying}>
                   <S.MyStudyFireIcon />
                   <S.MyStudyTime $isActive={isStudying} $loading={isLoading}>
-                    {displayStudyTime}
+                    {isLoading ? (
+                      <Skeleton width="8ch" height="1.5rem" radius="0.375rem" />
+                    ) : (
+                      displayStudyTime
+                    )}
                   </S.MyStudyTime>
                 </S.MyStudySummary>
               </S.HeaderTimer>
@@ -101,9 +105,13 @@ export const GroupActivity = ({
                       </Button>
                     </S.ActivityState>
                   ) : activityQuery.isPending ? (
-                    <S.ActivityState kind="loading">
-                      <S.ActivityStateTitle>그룹 활동을 불러오는 중이에요.</S.ActivityStateTitle>
-                    </S.ActivityState>
+                    <SkeletonRows
+                      ariaLabel="그룹 활동을 불러오는 중"
+                      rows={5}
+                      showTrailing={false}
+                      surface
+                      compact
+                    />
                   ) : groupMembers.length === 0 ? (
                     <S.ActivityState kind="empty">
                       <S.ActivityStateTitle>표시할 그룹 활동이 아직 없어요.</S.ActivityStateTitle>

--- a/apps/mac/src/renderer/src/widgets/home-rivals/Rival.tsx
+++ b/apps/mac/src/renderer/src/widgets/home-rivals/Rival.tsx
@@ -1,6 +1,6 @@
 import * as S from "./Rival.style";
 import { RivalsManagementDialog, useRival } from "@/features/rival-management";
-import { Button, QuestionTooltip } from "@/shared/ui";
+import { Button, QuestionTooltip, SkeletonCards } from "@/shared/ui";
 import { MyRivalUsers } from "./MyRivalUsers";
 import { getErrorMessage } from "@/shared/lib";
 
@@ -46,9 +46,7 @@ export const Rival = () => {
 
       <S.RivalBox aria-busy={rival.queries.myRivals.isFetching || undefined}>
         {rival.queries.myRivals.isPending ? (
-          <S.RivalState kind="loading">
-            <S.RivalStateTitle>라이벌을 불러오는 중이에요.</S.RivalStateTitle>
-          </S.RivalState>
+          <SkeletonCards ariaLabel="라이벌을 불러오는 중" cards={4} />
         ) : rival.queries.myRivals.isError && !rival.rivalsData ? (
           <S.RivalState kind="error">
             <S.RivalStateTitle>라이벌을 불러오지 못했어요.</S.RivalStateTitle>

--- a/apps/mac/src/renderer/src/widgets/profile-rivals/RivalContainer.tsx
+++ b/apps/mac/src/renderer/src/widgets/profile-rivals/RivalContainer.tsx
@@ -1,7 +1,7 @@
 import * as S from "./RivalContainer.style";
 import { RivalCard } from "./rival-card/RivalCard";
 import { RivalsManagementDialog, useRival } from "@/features/rival-management";
-import { Button } from "@/shared/ui";
+import { Button, SkeletonRows } from "@/shared/ui";
 import { getErrorMessage } from "@/shared/lib";
 
 export const RivalContainer = () => {
@@ -26,9 +26,13 @@ export const RivalContainer = () => {
       )}
       <S.Container>
         {rival.queries.myRivals.isPending ? (
-          <S.State role="status" aria-live="polite">
-            라이벌을 불러오는 중이에요.
-          </S.State>
+          <SkeletonRows
+            ariaLabel="라이벌을 불러오는 중"
+            rows={4}
+            showTrailing={false}
+            surface
+            compact
+          />
         ) : rival.queries.myRivals.isError && !rival.rivalsData ? (
           <S.State role="alert">
             <span>


### PR DESCRIPTION
## 변경사항

- 주요 화면의 초기 데이터 로딩 상태에 화면 구조를 반영한 스켈레톤 UI를 적용했습니다.
- 공통 스켈레톤 컴포넌트와 그룹 페이지 전용 스켈레톤을 추가했습니다.
- 스켈레톤 색상을 theme의 fill.neutral로 통일했습니다.

## 관련 이슈

Closes #645

## 스크린샷/동영상

## 추가 컨텍스트