### PR TITLE
fix: primary accent color/#649

### DIFF
--- a/apps/mac/src/renderer/src/features/announcement/ui/GlobalAnnouncementDialog.style.ts
+++ b/apps/mac/src/renderer/src/features/announcement/ui/GlobalAnnouncementDialog.style.ts
@@ -161,7 +161,7 @@ export const Content = styled.div`
 `;
 
 export const ContentLink = styled.a`
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
   text-decoration: underline;
   cursor: pointer;
 `;

--- a/apps/mac/src/renderer/src/features/chapter-ranking/ui/ChapterRanking.style.ts
+++ b/apps/mac/src/renderer/src/features/chapter-ranking/ui/ChapterRanking.style.ts
@@ -251,7 +251,7 @@ export const RankingUsername = styled.span`
 
 export const RankingChapter = styled.span`
   ${font.label.medium};
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
   text-align: center;
 `;
 

--- a/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.style.ts
+++ b/apps/mac/src/renderer/src/features/chapter/components/MissionContainer.style.ts
@@ -187,7 +187,7 @@ export const QuizProgress = styled.div`
 export const QuizStep = styled.span`
   ${font.body.regular}
   font-size: 1.1rem;
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const QuizProgressTrack = styled.div`
@@ -235,7 +235,7 @@ export const QuestionText = styled.div`
 
 export const QuestionPrefix = styled.span`
   ${font.title1.medium}
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const OptionList = styled.div`
@@ -348,7 +348,7 @@ export const SummaryScore = styled.div`
   gap: 0.3rem;
   ${font.title1.medium}
   font-size: 1.85rem;
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const SummaryScoreTotal = styled.span`

--- a/apps/mac/src/renderer/src/features/github/ui/GitHubDialog.style.ts
+++ b/apps/mac/src/renderer/src/features/github/ui/GitHubDialog.style.ts
@@ -27,7 +27,7 @@ export const SubDescription = styled.p`
 
 export const ErrorText = styled.p`
   ${font.caption.medium}
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const Actions = styled.div`

--- a/apps/mac/src/renderer/src/features/group/ui/group-side-tab/panel/GroupFormPanel.style.ts
+++ b/apps/mac/src/renderer/src/features/group/ui/group-side-tab/panel/GroupFormPanel.style.ts
@@ -113,7 +113,7 @@ export const GroupMembers = styled.span`
   flex-shrink: 0;
 
   span {
-    color: ${({ theme }) => theme.content.accent};
+    color: ${({ theme }) => theme.primary.normal};
   }
 `;
 

--- a/apps/mac/src/renderer/src/features/group/ui/group/modal/GroupJoinPassword.style.ts
+++ b/apps/mac/src/renderer/src/features/group/ui/group/modal/GroupJoinPassword.style.ts
@@ -33,5 +33,5 @@ export const PasswordInput = styled.input`
 export const PasswordErrorText = styled.p`
   margin-top: 0.5rem;
   ${font.label.medium};
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;

--- a/apps/mac/src/renderer/src/features/section-progress/ui/SectionProgress.style.ts
+++ b/apps/mac/src/renderer/src/features/section-progress/ui/SectionProgress.style.ts
@@ -57,7 +57,7 @@ export const StepCount = styled.span`
 `;
 
 export const CompletedCount = styled.span`
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const ProgressBarWrapper = styled.div`

--- a/apps/mac/src/renderer/src/features/section/components/PreviewModal.style.ts
+++ b/apps/mac/src/renderer/src/features/section/components/PreviewModal.style.ts
@@ -364,7 +364,7 @@ export const ArrowIcon = styled(Arrow)<{ $direction: "left" | "right" }>`
 
 export const CurrentStepLabel = styled.span`
   ${font.title2.medium}
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const StepLabel = styled.div`

--- a/apps/mac/src/renderer/src/shared/ui/level-slider/level-slider-field/LevelSliderField.style.ts
+++ b/apps/mac/src/renderer/src/shared/ui/level-slider/level-slider-field/LevelSliderField.style.ts
@@ -43,6 +43,6 @@ export const ThumbGrid = styled.span`
 
 export const FieldLabel = styled.span<{ $isActive: boolean }>`
   ${({ $isActive }) => ($isActive ? font.body.bold : font.body.medium)};
-  color: ${({ theme, $isActive }) => ($isActive ? theme.content.accent : theme.label.alternative)};
+  color: ${({ theme, $isActive }) => ($isActive ? theme.primary.normal : theme.label.alternative)};
   text-align: center;
 `;

--- a/apps/mac/src/renderer/src/widgets/group-activity/ui/GroupActivity.style.ts
+++ b/apps/mac/src/renderer/src/widgets/group-activity/ui/GroupActivity.style.ts
@@ -74,7 +74,7 @@ export const MyStudySummary = styled.div<{ $isActive: boolean }>`
   justify-content: center;
   gap: 0.875rem;
   margin-top: 1rem;
-  color: ${({ $isActive, theme }) => ($isActive ? theme.content.accent : theme.line.normal)};
+  color: ${({ $isActive, theme }) => ($isActive ? theme.primary.normal : theme.line.normal)};
 `;
 
 export const MyStudyFireIcon = styled(Fire)`
@@ -84,7 +84,7 @@ export const MyStudyFireIcon = styled(Fire)`
 
 export const MyStudyTime = styled.span<{ $isActive: boolean; $loading?: boolean }>`
   ${font.headline1.medium}
-  color: ${({ $isActive, theme }) => ($isActive ? theme.content.accent : theme.label.assistive)};
+  color: ${({ $isActive, theme }) => ($isActive ? theme.primary.normal : theme.label.assistive)};
   opacity: ${({ $loading }) => ($loading ? 0.48 : 1)};
 `;
 
@@ -105,7 +105,7 @@ export const MemberCapacityText = styled.p`
 `;
 
 export const CurrentMemberCount = styled.span`
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const GroupTitle = styled.span`
@@ -129,7 +129,7 @@ export const ActiveStudyingText = styled.p`
 `;
 
 export const ActiveStudyingCount = styled.span`
-  color: ${({ theme }) => theme.content.accent};
+  color: ${({ theme }) => theme.primary.normal};
 `;
 
 export const EmptyGroupState = styled.div`
@@ -216,10 +216,10 @@ export const MemberBox = styled.div<{ $isActive: boolean }>`
   align-items: center;
   justify-content: center;
   gap: 0.875rem;
-  color: ${({ $isActive, theme }) => ($isActive ? theme.content.accent : theme.line.normal)};
+  color: ${({ $isActive, theme }) => ($isActive ? theme.primary.normal : theme.line.normal)};
 
   ${MemberStudyTime} {
-    color: ${({ $isActive, theme }) => ($isActive ? theme.content.accent : theme.label.assistive)};
+    color: ${({ $isActive, theme }) => ($isActive ? theme.primary.normal : theme.label.assistive)};
   }
 
   ${MemberName} {

--- a/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.style.ts
+++ b/apps/mac/src/renderer/src/widgets/sidebar/Sidebar.style.ts
@@ -98,7 +98,7 @@ export const MenuItem = styled(Link)<{ $active?: boolean }>`
   gap: 0.625rem;
   ${font.headline2.medium}
   padding: 0.625rem 2rem;
-  color: ${({ $active, theme }) => ($active ? theme.label.strong : theme.label.normal)};
+  color: ${({ $active, theme }) => ($active ? theme.primary.normal : theme.label.normal)};
   cursor: pointer;
   transition: color 0.2s ease;
 

--- a/apps/mac/src/renderer/src/widgets/topbar/Topbar.style.ts
+++ b/apps/mac/src/renderer/src/widgets/topbar/Topbar.style.ts
@@ -154,7 +154,7 @@ export const MenuItem = styled.button<{ $isLogout: boolean }>`
   background: none;
   border: none;
   ${font.body.regular};
-  color: ${({ theme, $isLogout }) => ($isLogout ? theme.content.accent : theme.label.normal)};
+  color: ${({ theme, $isLogout }) => ($isLogout ? theme.primary.normal : theme.label.normal)};
   cursor: pointer;
 
   &:hover {


### PR DESCRIPTION
## 변경사항

- Sidebar, 그룹 활동, 로드맵의 강조색을 Primary 색상으로 복원했습니다.
- mac UI에 남아 있던 content.accent 사용을 primary.normal로 통일했습니다.
- danger와 focus border 등 별도 상태 색상은 유지했습니다.

## 관련 이슈

Closes #649

## 스크린샷/동영상

## 추가 컨텍스트